### PR TITLE
feat: add command and extra_content to control plane

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -13,6 +13,7 @@ module "s3" {
   description = var.description
   locations = var.locations
   private_package = var.private_package
+  extra_content = var.extra_content
 }
 
 module "alb" {
@@ -35,4 +36,5 @@ module "ecs" {
   private_package = var.private_package
   alb_security_group_ids = var.alb_security_group_ids
   alb_target_group_arn = module.alb.target_group_arn
+  command = var.command
 }

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -25,6 +25,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
     {
       name : "control-plane"
       image : var.image
+      command: var.command,
       cpu : 0
       essential : true
       portMappings : length(var.private_package) > 0 ? [

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -42,3 +42,9 @@ variable "alb_target_group_arn" {
   description = "Private Package ALB Target Group ARN."
   type        = string
 }
+
+variable "command" {
+  description = "Control plane image command"
+  type = list(string)
+  default = []
+}

--- a/terraform/aws/control-plane/modules/s3/main.tf
+++ b/terraform/aws/control-plane/modules/s3/main.tf
@@ -7,11 +7,11 @@ resource "aws_s3_object" "conf" {
   key    = var.object_name
   content_type = "application/json"
   content = jsonencode({
-    control-plane : {
+    control-plane : merge(var.extra_content, {
       token : var.token,
       description : var.description,
       locations :  [for location in var.locations : location.conf]
       repository : length(var.private_package) > 0 ? var.private_package.conf : {}
-    }
+    })
   })
 }

--- a/terraform/aws/control-plane/modules/s3/variables.tf
+++ b/terraform/aws/control-plane/modules/s3/variables.tf
@@ -28,3 +28,8 @@ variable "private_package" {
   description = "JSON configuration for the Private Package."
   type        = map(any)
 }
+
+variable "extra_content" {
+  type = map(any)
+  default = {}
+}

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -64,3 +64,14 @@ variable "private_package" {
   type        = map(any)
   default     = {}
 }
+
+variable "extra_content" {
+  type = map(any)
+  default = {}
+}
+
+variable "command" {
+  description = "Control plane image command"
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
**Motivation:**
`command` allow custom command for the control plane image. `extra_content` alllow extra properties in `control-plane.conf`