### PR TITLE
feat: AWS Terraform CloudWatch Logs

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -1,29 +1,29 @@
 module "iam" {
-  source = "./modules/iam"
-  name = "${var.name}-role"
-  s3_bucket_name = var.conf_s3_name
-  private_package =  var.private_package
+  source          = "./modules/iam"
+  name            = "${var.name}-role"
+  s3_bucket_name  = var.conf_s3_name
+  private_package = var.private_package
 }
 
 module "s3" {
-  source = "./modules/s3"
-  name = var.conf_s3_name
-  object_name = var.conf_s3_object_name
-  token = var.token
-  description = var.description
-  locations = var.locations
+  source          = "./modules/s3"
+  name            = var.conf_s3_name
+  object_name     = var.conf_s3_object_name
+  token           = var.token
+  description     = var.description
+  locations       = var.locations
   private_package = var.private_package
-  extra_content = var.extra_content
+  extra_content   = var.extra_content
 }
 
 module "ecs" {
-  source = "./modules/ecs"
-  name = var.name
-  image = var.image
-  subnet_ids = var.subnet_ids
-  security_group_ids = var.security_group_ids
-  conf_s3_name = var.conf_s3_name
-  ecs_tasks_iam_role_arn =  module.iam.ecs_tasks_iam_role_arn
-  private_package = var.private_package
-  command = var.command
+  source                 = "./modules/ecs"
+  name                   = var.name
+  image                  = var.image
+  subnet_ids             = var.subnet_ids
+  security_group_ids     = var.security_group_ids
+  conf_s3_name           = var.conf_s3_name
+  ecs_tasks_iam_role_arn = module.iam.ecs_tasks_iam_role_arn
+  private_package        = var.private_package
+  command                = var.command
 }

--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -3,6 +3,7 @@ module "iam" {
   name            = "${var.name}-role"
   s3_bucket_name  = var.conf_s3_name
   private_package = var.private_package
+  cloudWatch_logs = var.cloudWatch_logs
 }
 
 module "s3" {
@@ -26,4 +27,5 @@ module "ecs" {
   ecs_tasks_iam_role_arn = module.iam.ecs_tasks_iam_role_arn
   private_package        = var.private_package
   command                = var.command
+  cloudWatch_logs        = var.cloudWatch_logs
 }

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -25,7 +25,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
     {
       name : "control-plane"
       image : var.image
-      command: var.command,
+      command : var.command,
       cpu : 0
       essential : true
       portMappings : length(var.private_package) > 0 ? [
@@ -42,7 +42,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
           readOnly : true
         }
       ]
-      dependsOn = [
+      dependsOn : [
         {
           containerName : "conf-loader-init-container"
           condition : "SUCCESS"

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -35,6 +35,6 @@ variable "private_package" {
 
 variable "command" {
   description = "Control plane image command"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -38,3 +38,8 @@ variable "command" {
   type        = list(string)
   default     = []
 }
+
+variable "cloudWatch_logs" {
+  description = "Control Plane CloudWatch Logs."
+  type        = bool
+}

--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -68,6 +68,24 @@ resource "aws_iam_policy" "pp_s3_policy" {
   })
 }
 
+resource "aws_iam_policy" "cloudwatch_logs_policy" {
+  count = var.cloudWatch_logs ? 1 : 0
+  name  = "${var.name}-CloudWatchLogsPolicy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
 
 resource "aws_iam_role_policy_attachment" "s3_policy_attachment" {
   role       = aws_iam_role.gatling_role.name
@@ -83,4 +101,10 @@ resource "aws_iam_role_policy_attachment" "pp_s3_policy_attachment" {
   count      = length(var.private_package) > 0 ? 1 : 0
   role       = aws_iam_role.gatling_role.name
   policy_arn = aws_iam_policy.pp_s3_policy[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy_attachment" {
+  count      = var.cloudWatch_logs ? 1 : 0
+  role       = aws_iam_role.gatling_role.name
+  policy_arn = aws_iam_policy.cloudwatch_logs_policy[0].arn
 }

--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "ec2_policy" {
 }
 
 resource "aws_iam_policy" "pp_s3_policy" {
-  count =  length(var.private_package) > 0 ? 1 : 0
+  count = length(var.private_package) > 0 ? 1 : 0
   name  = "${var.name}-PackagePolicy"
   policy = jsonencode({
     Version = "2012-10-17",
@@ -80,7 +80,7 @@ resource "aws_iam_role_policy_attachment" "ec2_policy_attachment" {
 }
 
 resource "aws_iam_role_policy_attachment" "pp_s3_policy_attachment" {
-  count =  length(var.private_package) > 0 ? 1 : 0
+  count      = length(var.private_package) > 0 ? 1 : 0
   role       = aws_iam_role.gatling_role.name
   policy_arn = aws_iam_policy.pp_s3_policy[0].arn
 }

--- a/terraform/aws/control-plane/modules/iam/outputs.tf
+++ b/terraform/aws/control-plane/modules/iam/outputs.tf
@@ -1,8 +1,3 @@
-output "ecs_tasks_iam_role_name" {
-  value       = aws_iam_role.gatling_role.name
-  description = "Control Plane IAM Role name."
-}
-
 output "ecs_tasks_iam_role_arn" {
   value       = aws_iam_role.gatling_role.arn
   description = "Control Plane IAM Role ARN."

--- a/terraform/aws/control-plane/modules/iam/variables.tf
+++ b/terraform/aws/control-plane/modules/iam/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   type        = string
-  description = "Name of the Control Plane role."
+  description = "Control Plane role name."
 }
 
 variable "s3_bucket_name" {
@@ -11,4 +11,9 @@ variable "s3_bucket_name" {
 variable "private_package" {
   description = "JSON configuration for the private packages."
   type        = map(any)
+}
+
+variable "cloudWatch_logs" {
+  description = "Control Plane CloudWatch Logs."
+  type        = bool
 }

--- a/terraform/aws/control-plane/modules/s3/main.tf
+++ b/terraform/aws/control-plane/modules/s3/main.tf
@@ -3,14 +3,14 @@ data "aws_s3_bucket" "s3_conf" {
 }
 
 resource "aws_s3_object" "conf" {
-  bucket = data.aws_s3_bucket.s3_conf.id
-  key    = var.object_name
+  bucket       = data.aws_s3_bucket.s3_conf.id
+  key          = var.object_name
   content_type = "application/json"
   content = jsonencode({
     control-plane : merge(var.extra_content, {
       token : var.token,
       description : var.description,
-      locations :  [for location in var.locations : location.conf]
+      locations : [for location in var.locations : location.conf]
       repository : length(var.private_package) > 0 ? var.private_package.conf : null
     })
   })

--- a/terraform/aws/control-plane/modules/s3/variables.tf
+++ b/terraform/aws/control-plane/modules/s3/variables.tf
@@ -30,6 +30,6 @@ variable "private_package" {
 }
 
 variable "extra_content" {
-  type = map(any)
+  type    = map(any)
   default = {}
 }

--- a/terraform/aws/control-plane/outputs.tf
+++ b/terraform/aws/control-plane/outputs.tf
@@ -1,4 +1,0 @@
-output "ecs_tasks_iam_role_name" {
-  value       = module.iam.ecs_tasks_iam_role_name
-  description = "Control Plane IAM Role name."
-}

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -54,12 +54,12 @@ variable "private_package" {
 }
 
 variable "extra_content" {
-  type = map(any)
+  type    = map(any)
   default = {}
 }
 
 variable "command" {
   description = "Control plane image command"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -67,5 +67,5 @@ variable "command" {
 variable "cloudWatch_logs" {
   description = "Control Plane Service CloudWatch logs."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -63,3 +63,9 @@ variable "command" {
   type        = list(string)
   default     = []
 }
+
+variable "cloudWatch_logs" {
+  description = "Control Plane Service CloudWatch logs."
+  type        = bool
+  default     = false
+}

--- a/terraform/aws/location/main.tf
+++ b/terraform/aws/location/main.tf
@@ -1,23 +1,23 @@
 locals {
   location = {
-        id : var.id,
-        description : var.description,
-        type : "aws",
-        region : var.region,
-        ami : {
-          type : var.ami_type,
-          java : var.java_version
-        },
-        subnets : var.subnet_ids,
-        security-groups : var.security_group_ids,
-        instance-type : var.instance_type,
-        spot : var.spot,
-        elastic-ips : var.elastic_ips,
-        profile_name : var.profile_name,
-        iam-instance-profile : var.iam_instance_profile,
-        tags : var.tags,
-        tags-for : var.tags_for,
-        java-home : var.java_home,
-        jvm-options : var.jvm_options,
+    id : var.id,
+    description : var.description,
+    type : "aws",
+    region : var.region,
+    ami : {
+      type : var.ami_type,
+      java : var.java_version
+    },
+    subnets : var.subnet_ids,
+    security-groups : var.security_group_ids,
+    instance-type : var.instance_type,
+    spot : var.spot,
+    elastic-ips : var.elastic_ips,
+    profile_name : var.profile_name,
+    iam-instance-profile : var.iam_instance_profile,
+    tags : var.tags,
+    tags-for : var.tags_for,
+    java-home : var.java_home,
+    jvm-options : var.jvm_options,
   }
 }

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -1,13 +1,13 @@
 variable "id" {
   type        = string
   description = "ID of the location."
-  default = "prl_private_location_example"
+  default     = "prl_private_location_example"
 }
 
 variable "description" {
   type        = string
   description = "Description of the location."
-  default = "Private Location on AWS"
+  default     = "Private Location on AWS"
 }
 
 variable "region" {
@@ -18,25 +18,25 @@ variable "region" {
 variable "instance_type" {
   type        = string
   description = "Instance type of the location."
-  default = "c7i.xlarge"
+  default     = "c7i.xlarge"
 }
 
 variable "spot" {
   type        = bool
   description = "Flag to enable spot instances."
-  default = false
+  default     = false
 }
 
 variable "ami_type" {
   type        = string
   description = "AMI type of the location."
-  default = "certified"
+  default     = "certified"
 }
 
 variable "java_version" {
   type        = string
   description = "Java version of the location."
-  default = "latest"
+  default     = "latest"
 }
 
 variable "subnet_ids" {
@@ -53,25 +53,25 @@ variable "security_group_ids" {
 variable "elastic_ips" {
   type        = list(string)
   description = "Assign elastic IPs to your Locations. You will only be able to deploy a number of load generators up to the number of Elastic IP addresses you have configured."
-  default = []
+  default     = []
 }
 
 variable "profile_name" {
   type        = string
   description = "Profile name to be assigned to the Location."
-  default = ""
+  default     = ""
 }
 
 variable "iam_instance_profile" {
   type        = string
   description = "IAM instance profile to be assigned to the Location."
-  default = ""
+  default     = ""
 }
 
 variable "tags" {
   description = "Tags to be assigned to the Location."
   type        = map(string)
-  default     = {
+  default = {
     # ExampleKey = "ExampleValue"
   }
 }
@@ -79,23 +79,23 @@ variable "tags" {
 variable "tags_for" {
   description = "Tags to be assigned to the resources of the Location."
   type        = map(map(string))
-  default     = {
-        instance : {
-          # ExampleKey = "ExampleValue"
-        }
-        volume : {
-          # ExampleKey = "ExampleValue"
-        }
-        network-interface : {
-          # ExampleKey = "ExampleValue"
-        }
-      }
+  default = {
+    instance : {
+      # ExampleKey = "ExampleValue"
+    }
+    volume : {
+      # ExampleKey = "ExampleValue"
+    }
+    network-interface : {
+      # ExampleKey = "ExampleValue"
+    }
+  }
 }
 
 variable "system_properties" {
   description = "System properties to be assigned to the Location."
   type        = map(string)
-  default     = {
+  default = {
     # ExampleKey = "ExampleValue"
   }
 }

--- a/terraform/examples/AWS-private-location/main.tf
+++ b/terraform/examples/AWS-private-location/main.tf
@@ -19,4 +19,5 @@ module "control-plane" {
   security_group_ids = ["sg-id"]
   conf_s3_name       = "conf_s3_name"
   locations          = [module.location]
+  //cloudWatch_logs    = true
 }

--- a/terraform/examples/AWS-private-location/main.tf
+++ b/terraform/examples/AWS-private-location/main.tf
@@ -12,11 +12,11 @@ module "location" {
 }
 
 module "control-plane" {
-  source              = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
-  name                = "name"
-  token               = "token"
-  subnet_ids          = ["subnet-a", "subnet-b"]
-  security_group_ids  = ["sg-id"]
-  conf_s3_name        = "conf_s3_name"
-  locations           = [module.location]
+  source             = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
+  name               = "name"
+  token              = "token"
+  subnet_ids         = ["subnet-a", "subnet-b"]
+  security_group_ids = ["sg-id"]
+  conf_s3_name       = "conf_s3_name"
+  locations          = [module.location]
 }

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -17,13 +17,13 @@ module "location" {
 }
 
 module "control-plane" {
-  source                 = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
-  name                   = "name"
-  token                  = "token"
-  vpc                    = "vpc-id"
-  subnet_ids             = ["subnet-a", "subnet-b"]
-  security_group_ids     = ["sg-id"]
-  conf_s3_name           = "conf_s3_name"
-  locations              = [module.location]
-  private_package        = module.private-package
+  source             = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
+  name               = "name"
+  token              = "token"
+  vpc                = "vpc-id"
+  subnet_ids         = ["subnet-a", "subnet-b"]
+  security_group_ids = ["sg-id"]
+  conf_s3_name       = "conf_s3_name"
+  locations          = [module.location]
+  private_package    = module.private-package
 }

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -26,4 +26,5 @@ module "control-plane" {
   conf_s3_name       = "conf_s3_name"
   locations          = [module.location]
   private_package    = module.private-package
+  //cloudWatch_logs    = true
 }


### PR DESCRIPTION
I'm adding support for optionally pushing Control Plane service logs to CloudWatch to help with deployment and debugging, as it's a recurring request from multiple prospects.

Changes Made:
- Added optional CloudWatch policy for Control Plane service role.
- Added optional logConfiguration to  Control Plane task definition.
- Refactoring


I believe I should add a section to our AWS Private Locations documentation detailing the necessary CloudWatch permissions and the changes needed in the service task definition. What do you think?