### PR TITLE
[Helm] Set QoS policies for CP and PL

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "1.0"
-version: 1.0.1
+version: 1.0.2
 name: enterprise-locations-packages
 description: Official Gatling Enterprise Helm chart for Private Locations & Packages
 home: https://gatling.io

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "1.0"
-version: 1.0.2
+version: 1.0.1
 name: enterprise-locations-packages
 description: Official Gatling Enterprise Helm chart for Private Locations & Packages
 home: https://gatling.io

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -63,11 +63,11 @@ spec:
           {{- end }}
           resources:
             requests:
-              memory: {{ .Values.controlPlane.resources.requests.memory | default "512Mi" }}
+              memory: {{ .Values.controlPlane.resources.requests.memory | default "1Gi" }}
               cpu: {{ .Values.controlPlane.resources.requests.cpu | default "1" }}
             limits:
-              memory: {{ .Values.controlPlane.resources.limits.memory | default "1024Mi" }}
-              cpu: {{ .Values.controlPlane.resources.limits.cpu | default "2" }}
+              memory: {{ .Values.controlPlane.resources.limits.memory | default "1Gi" }}
+              cpu: {{ .Values.controlPlane.resources.limits.cpu | default "1" }}
           volumeMounts:
             - mountPath: /app/conf/
               name: "{{ .Values.controlPlane.name }}-conf-volume"

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -61,10 +61,13 @@ spec:
           env:
             {{ toYaml .Values.controlPlane.env | nindent 12 }}
           {{- end }}
-          {{- if .Values.controlPlane.resources }}
           resources:
-            {{ toYaml .Values.controlPlane.resources | nindent 12 }}
-          {{- end }}
+            requests:
+              memory: {{ .Values.controlPlane.resources.requests.memory | default "512Mi" }}
+              cpu: {{ .Values.controlPlane.resources.requests.cpu | default "1" }}
+            limits:
+              memory: {{ .Values.controlPlane.resources.limits.memory | default "1024Mi" }}
+              cpu: {{ .Values.controlPlane.resources.limits.cpu | default "2" }}
           volumeMounts:
             - mountPath: /app/conf/
               name: "{{ .Values.controlPlane.name }}-conf-volume"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -41,12 +41,12 @@ controlPlane:
   resources: 
     # Resource requests for the container
     requests:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "1"
     # Resource limits for the container
     limits:
-      memory: "1024Mi"
-      cpu: "2"
+      memory: "1Gi"
+      cpu: "1"
   # Security context for the pod or container
   securityContext: {}
   #enterpriseCloud:
@@ -85,12 +85,12 @@ privateLocations:
                 resources:
                   # Resource requests for the container
                   limits": 
-                    memory: "512Mi"
-                    cpu: "1"
+                    memory: "2Gi"
+                    cpu: "2"
                   # Resource limits for the container
                   requests:
-                    memory: "1024Mi"
-                    cpu: "2"
+                    memory: "1Gi"
+                    cpu: "1"
             # Security context for the pod or container
             securityContext:
               sysctls: []  # List of sysctls to set in the pod

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -38,7 +38,7 @@ controlPlane:
   affinity: {}
   # Tolerations to allow pods to be scheduled on tainted nodes
   tolerations: {}
-  resources: 
+  resources: # Recommended: Guaranteed QoS class.
     # Resource requests for the container
     requests:
       memory: "1Gi"
@@ -82,7 +82,7 @@ privateLocations:
             containers:
               - env: []  # Environment variables for the container
                 name: gatling-container  # Name of the container
-                resources:
+                resources: # Recommended: Burstable QoS class.
                   # Resource requests for the container
                   limits": 
                     memory: "2Gi"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -45,8 +45,8 @@ controlPlane:
       cpu: "1"
     # Resource limits for the container
     limits:
-      memory: "512Mi"
-      cpu: "1"
+      memory: "1024Mi"
+      cpu: "2"
   # Security context for the pod or container
   securityContext: {}
   #enterpriseCloud:
@@ -86,11 +86,11 @@ privateLocations:
                   # Resource requests for the container
                   limits": 
                     memory: "512Mi"
-                    cpu: "4"
+                    cpu: "1"
                   # Resource limits for the container
                   requests:
-                    memory: "512Mi"
-                    cpu: "4"
+                    memory: "1024Mi"
+                    cpu: "2"
             # Security context for the pod or container
             securityContext:
               sysctls: []  # List of sysctls to set in the pod


### PR DESCRIPTION
Motivation:
- Set load generators as burstable by default. This allows resources to scale dynamically based on load tests. Throttling or evicting these jobs when fully saturated makes sense, as the load test can simply be restarted if necessary.
- Set control plane to guaranteed QoS class by default, as its role as the orchestrator of load generators makes evictions unacceptable.
https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes

Modifications:
- Set same control plane resource requests and resource limits in order to ensure guaranteed QoS class.
- Set different load generator resource requests and resource limits in order to ensure burstable QoS class.