### PR TITLE
[Terraform-Azure] v2 - Reference secret through Key Vault

### DIFF
--- a/terraform/azure/control-plane/main.tf
+++ b/terraform/azure/control-plane/main.tf
@@ -6,6 +6,7 @@ module "storage-account" {
   storage_account_name = var.storage_account_name
   conf_share_file_name = var.conf_share_file_name
   locations            = var.locations
+  enterprise_cloud     = var.enterprise_cloud
   private_package      = var.private_package
   extra_content        = var.extra_content
 }
@@ -21,6 +22,7 @@ module "container-app" {
   storage_share_name                 = module.storage-account.storage_share_name
   private_package                    = var.private_package
   command                            = var.command
+  enterprise_cloud                   = var.enterprise_cloud
 }
 
 module "role-assignment" {

--- a/terraform/azure/control-plane/main.tf
+++ b/terraform/azure/control-plane/main.tf
@@ -1,6 +1,5 @@
 module "storage-account" {
   source               = "./modules/storage-account"
-  token                = var.token
   description          = var.description
   resource_group_name  = var.resource_group_name
   storage_account_name = var.storage_account_name
@@ -15,6 +14,7 @@ module "container-app" {
   source                             = "./modules/container-app"
   name                               = var.name
   image                              = var.image
+  secret_id                          = var.secret_id
   resource_group_name                = var.resource_group_name
   region                             = var.region
   storage_account_name               = var.storage_account_name
@@ -26,7 +26,9 @@ module "container-app" {
 }
 
 module "role-assignment" {
-  source          = "./modules/role-assignment"
-  container       = module.container-app.container
-  private_package = var.private_package
+  source              = "./modules/role-assignment"
+  resource_group_name = var.resource_group_name
+  vault_name          = var.vault_name
+  container           = module.container-app.container
+  private_package     = var.private_package
 }

--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -39,6 +39,12 @@ resource "azurerm_container_app" "gatling_container" {
     }
   }
 
+  secret {
+    name                = "token-secret-id"
+    key_vault_secret_id = var.secret_id
+    identity            = "System"
+  }
+
   template {
     min_replicas = 1
     max_replicas = 1
@@ -50,10 +56,16 @@ resource "azurerm_container_app" "gatling_container" {
       memory  = "2Gi"
       command = var.command
 
+      env {
+        name        = "CONTROL_PLANE_TOKEN"
+        secret_name = "token-secret-id"
+      }
+
       volume_mounts {
         name = "control-plane-conf"
         path = "/app/conf"
       }
+
     }
 
     volume {
@@ -61,6 +73,7 @@ resource "azurerm_container_app" "gatling_container" {
       storage_name = "control-plane-conf"
       storage_type = "AzureFile"
     }
+
   }
 
   depends_on = [

--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_container_app" "gatling_container" {
     for_each = length(var.private_package) > 0 ? [1] : []
     content {
       external_enabled = true
-      target_port      = 8080
+      target_port      = var.private_package.conf.server.port
       traffic_weight {
         percentage      = 100
         latest_revision = true

--- a/terraform/azure/control-plane/modules/container-app/variables.tf
+++ b/terraform/azure/control-plane/modules/container-app/variables.tf
@@ -48,3 +48,7 @@ variable "command" {
 variable "enterprise_cloud" {
   type    = map(any)
 }
+
+variable "secret_id" {
+  type = string
+}

--- a/terraform/azure/control-plane/modules/container-app/variables.tf
+++ b/terraform/azure/control-plane/modules/container-app/variables.tf
@@ -44,3 +44,7 @@ variable "command" {
   type        = list(string)
   default     = []
 }
+
+variable "enterprise_cloud" {
+  type    = map(any)
+}

--- a/terraform/azure/control-plane/modules/role-assignment/main.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/main.tf
@@ -1,5 +1,16 @@
 data "azurerm_subscription" "current" {}
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault_access_policy" "container_app_policy" {
+  key_vault_id = "${data.azurerm_subscription.current.id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.KeyVault/vaults/${var.vault_name}"
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = var.container.identity[0].principal_id
+
+  secret_permissions = ["Get"]
+}
+
 resource "azurerm_role_definition" "gatling_custom_role" {
   name        = "Gatling Role"
   scope       = data.azurerm_subscription.current.id

--- a/terraform/azure/control-plane/modules/role-assignment/variables.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/variables.tf
@@ -1,10 +1,20 @@
 variable "container" {
-  type        = any
   description = "Container running the control plane."
+  type        = any
 }
 
 variable "private_package" {
   description = "JSON configuration for the private packages."
   type        = map(any)
   default     = {}
+}
+
+variable "resource_group_name" {
+  description = "Resource group name."
+  type        = string
+}
+
+variable "vault_name" {
+  description = "Vault name where the token plane secret is stored."
+  type = string
 }

--- a/terraform/azure/control-plane/modules/storage-account/main.tf
+++ b/terraform/azure/control-plane/modules/storage-account/main.tf
@@ -4,9 +4,9 @@ data "azurerm_storage_account" "gatling_storage_account" {
 }
 
 resource "azurerm_storage_share" "gatling_storage_share" {
-  name                 = "${var.storage_account_name}-fs"
-  storage_account_name = var.storage_account_name
-  quota                = 50
+  name               = "${var.storage_account_name}-fs"
+  storage_account_id = data.azurerm_storage_account.gatling_storage_account.id
+  quota              = 50
 }
 
 resource "local_file" "json_file" {
@@ -24,7 +24,7 @@ resource "local_file" "json_file" {
 
 resource "azurerm_storage_share_file" "gatling_storage_share_file" {
   name             = var.conf_share_file_name
-  storage_share_id = azurerm_storage_share.gatling_storage_share.id
+  storage_share_id = azurerm_storage_share.gatling_storage_share.url
   source           = local_file.json_file.filename
 
   lifecycle {

--- a/terraform/azure/control-plane/modules/storage-account/main.tf
+++ b/terraform/azure/control-plane/modules/storage-account/main.tf
@@ -16,6 +16,7 @@ resource "local_file" "json_file" {
       token : var.token
       description : var.description
       locations : [for location in var.locations : location.conf]
+      enterprise_cloud : var.enterprise_cloud
       repository : length(var.private_package) > 0 ? var.private_package.conf : {}
     })
   })

--- a/terraform/azure/control-plane/modules/storage-account/main.tf
+++ b/terraform/azure/control-plane/modules/storage-account/main.tf
@@ -11,15 +11,16 @@ resource "azurerm_storage_share" "gatling_storage_share" {
 
 resource "local_file" "json_file" {
   filename = var.conf_share_file_name
-  content = jsonencode({
-    control-plane : merge(var.extra_content, {
-      token : var.token
-      description : var.description
-      locations : [for location in var.locations : location.conf]
-      enterprise_cloud : var.enterprise_cloud
-      repository : length(var.private_package) > 0 ? var.private_package.conf : {}
-    })
-  })
+  content = <<-EOF
+    control-plane {
+      token = $${?CONTROL_PLANE_TOKEN}
+      description = "${var.description}"
+      enterprise-cloud = { %{for key, value in var.enterprise_cloud} ${key} = "${value}" %{endfor} }
+      locations = [ %{for location in var.locations} ${jsonencode(location.conf)}, %{endfor} ]
+      %{if length(var.private_package) > 0}repository = ${jsonencode(var.private_package.conf)}%{endif}
+      %{for key, value in var.extra_content}${key} = "${value}"%{endfor}
+    }
+  EOF
 }
 
 resource "azurerm_storage_share_file" "gatling_storage_share_file" {

--- a/terraform/azure/control-plane/modules/storage-account/variables.tf
+++ b/terraform/azure/control-plane/modules/storage-account/variables.tf
@@ -1,9 +1,3 @@
-variable "token" {
-  type        = string
-  description = "Token of the control plane"
-  sensitive   = true
-}
-
 variable "description" {
   type        = string
   description = "Description of the control plane."

--- a/terraform/azure/control-plane/modules/storage-account/variables.tf
+++ b/terraform/azure/control-plane/modules/storage-account/variables.tf
@@ -29,6 +29,10 @@ variable "locations" {
   type        = list(any)
 }
 
+variable "enterprise_cloud" {
+  type    = map(any)
+}
+
 variable "private_package" {
   description = "JSON configuration for the private packages."
   type        = map(any)

--- a/terraform/azure/control-plane/variables.tf
+++ b/terraform/azure/control-plane/variables.tf
@@ -63,3 +63,8 @@ variable "command" {
   type        = list(string)
   default     = []
 }
+
+variable "enterprise_cloud" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/azure/control-plane/variables.tf
+++ b/terraform/azure/control-plane/variables.tf
@@ -1,9 +1,3 @@
-variable "token" {
-  type        = string
-  description = "Token of the control plane"
-  sensitive   = true
-}
-
 variable "name" {
   type        = string
   description = "Name of the control plane"
@@ -67,4 +61,13 @@ variable "command" {
 variable "enterprise_cloud" {
   type    = map(any)
   default = {}
+}
+
+variable "vault_name" {
+  description = "Vault name where the token plane secret is stored."
+  type = string
+}
+
+variable "secret_id" {
+  type = string
 }

--- a/terraform/azure/location/main.tf
+++ b/terraform/azure/location/main.tf
@@ -15,6 +15,7 @@ locals {
     associate-public-ip : var.associate_public_ip
     system-properties : var.system_properties
     java-home : var.java_home
-    jvm-options : var.jvm_options,
+    jvm-options : var.jvm_options
+    enterprise-cloud : var.enterprise_cloud 
   }
 }

--- a/terraform/azure/location/variables.tf
+++ b/terraform/azure/location/variables.tf
@@ -77,3 +77,8 @@ variable "jvm_options" {
   type        = list(string)
   default     = []
 }
+
+variable "enterprise_cloud" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/azure/private-package/main.tf
+++ b/terraform/azure/private-package/main.tf
@@ -4,5 +4,16 @@ locals {
     storage-account : var.storage_account_name
     container : var.container_name
     path : var.path
+    upload : {
+      directory = var.uploadDir
+    }
+    server : {
+      port : var.port
+      bindAddress : var.bindAddress
+      certificate : length(var.certPath) > 0 ? {
+        path : var.certPath
+        password : var.certPassword
+      } : null
+    }
   }
 }

--- a/terraform/azure/private-package/variables.tf
+++ b/terraform/azure/private-package/variables.tf
@@ -13,3 +13,33 @@ variable "path" {
   description = "Storage path on the S3 private package."
   default     = ""
 }
+
+variable "uploadDir" {
+  type        = string
+  description = "Control Plane Repository Server Temporary Upload Directory."
+  default     = "/tmp"
+}
+
+variable "port" {
+  type        = number
+  description = "Control Plane Repository Server Port."
+  default     = 8080
+}
+
+variable "bindAddress" {
+  type        = string
+  description = "Control Plane Repository Server Bind Address."
+  default     = "0.0.0.0"
+}
+
+variable "certPath" {
+  type        = string
+  description = "Control Plane Repository Server Certificate Path."
+  default     = ""
+}
+
+variable "certPassword" {
+  type        = string
+  description = "Control Plane Repository Server Certificate Password."
+  default     = ""
+}

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -5,7 +5,7 @@ This Terraform configuration sets up the Azure infrastructure for Gatling Enterp
 ## Prerequisites
 
 - Gatling Enterprise [account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/auth?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) with Private Locations enabled. To access this feature, please contact our [technical support](https://gatlingcorp.atlassian.net/servicedesk/customer/portal/8/group/12/create/59?summary=Private+Locations&description=Contact%20email%3A%20%3Cemail%3E%0A%0AHello%2C%20we%20would%20like%20to%20enable%20the%20private%20locations%20feature%20on%20our%20organization.).
-- A control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token).
+- A control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token) stored in Azure Vault as a secret.
 - Terraform installed on your local machine.
 - Azure credentials configured.
 
@@ -63,9 +63,10 @@ Sets up the control plane with configurations for networking, security, and stor
 module "control-plane" {
   source               = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "gatling-cp"
-  token                = "token"
   region               = "westeurope"
   resource_group_name  = "resource-group-name"
+  vault_name           = "vault-name"
+  secret_id            = "token-secret-identifier"
   storage_account_name = "storage-account-name"
   locations            = [module.location]
 }
@@ -73,9 +74,10 @@ module "control-plane" {
 
 - `source` (required): The source of the module, pointing to the GitHub repository.
 - `name` (required): The name of the control plane.
-- `token` (required): The control plane token for authentication.
 - `region` (required): The Azure region to deploy to.
 - `resource_group_name` (required): The name of the resource group where the control plane will be deployed.
+- `vault_name`(required): Vault name where the control plane secret token is stored.
+- `secret_id`(required): Secret identifier for the stored control plane token.
 - `storage_account_name` (required): The storage account name where configurations will be stored.
 - `locations` (required): The list of location module(s).
 - `image`: Image of the control plane.

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -53,6 +53,7 @@ module "location" {
 - `system_properties`: System properties to be assigned to the Location.
 - `java_home`: Overwrite JAVA_HOME definition.
 - `jvm_options`: Overwrite JAVA_HOME definition.
+- `enterprise_cloud.url`: Set up a forward proxy for the control plane.
 
 ### Control Plane
 
@@ -80,6 +81,7 @@ module "control-plane" {
 - `image`: Image of the control plane.
 - `description`: Description of the control plane.
 - `conf_share_file_name`: The name of the configuration object in the file share.
+- `enterprise_cloud.url`: Set up a forward proxy for the control plane.
 
 ## Usage
 

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -6,6 +6,7 @@ This Terraform configuration sets up the Azure infrastructure for Gatling Enterp
 
 - Gatling Enterprise [account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/auth?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) with Private Locations enabled. To access this feature, please contact our [technical support](https://gatlingcorp.atlassian.net/servicedesk/customer/portal/8/group/12/create/59?summary=Private+Locations&description=Contact%20email%3A%20%3Cemail%3E%0A%0AHello%2C%20we%20would%20like%20to%20enable%20the%20private%20locations%20feature%20on%20our%20organization.).
 - A control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token) stored in Azure Vault as a secret.
+- A storage account to be mounted as a container volume.
 - Terraform installed on your local machine.
 - Azure credentials configured.
 
@@ -37,6 +38,9 @@ module "location" {
   subnet_name         = "default"
   size                = "Standard_A4_v2"
   engine              = "classic"
+  //enterprise_cloud    = {
+    //url = ""  // http://private-location-forward-proxy/gatling
+  //}
 }
 ```
 
@@ -69,6 +73,9 @@ module "control-plane" {
   secret_id            = "token-secret-identifier"
   storage_account_name = "storage-account-name"
   locations            = [module.location]
+  //enterprise_cloud    = {
+    //url = ""  // http://private-control-plane-forward-proxy/gatling
+  //}
 }
 ```
 

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -11,6 +11,9 @@ module "location" {
   subnet_name         = "default"
   //size                = "Standard_A4_v2"
   //engine              = "classic"
+  //enterprise_cloud    = {
+    //url = ""  // http://private-location-forward-proxy/gatling
+  //}
 }
 
 module "control-plane" {
@@ -22,4 +25,7 @@ module "control-plane" {
   secret_id            = "token-secret-identifier"
   storage_account_name = "storage-account-name"
   locations            = [module.location]
+  //enterprise_cloud    = {
+    //url = ""  // http://private-control-plane-forward-proxy/gatling
+  //}
 }

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -16,9 +16,10 @@ module "location" {
 module "control-plane" {
   source               = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "gatling-cp"
-  token                = "token"
   region               = "westeurope"
   resource_group_name  = "resource-group-name"
+  vault_name           = "vault-name"
+  secret_id            = "token-secret-identifier"
   storage_account_name = "storage-account-name"
   locations            = [module.location]
 }

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -5,7 +5,7 @@ This Terraform configuration sets up the Azure infrastructure for Gatling Enterp
 ## Prerequisites
 
 - Gatling Enterprise [account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/auth?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) with Private Locations enabled. To access this feature, please contact our [technical support](https://gatlingcorp.atlassian.net/servicedesk/customer/portal/8/group/12/create/59?summary=Private+Locations&description=Contact%20email%3A%20%3Cemail%3E%0A%0AHello%2C%20we%20would%20like%20to%20enable%20the%20private%20locations%20feature%20on%20our%20organization.).
-- A control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token).
+- A control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token) stored in Azure Vault as a secret.
 - Terraform installed on your local machine.
 - Azure credentials configured.
 
@@ -90,9 +90,10 @@ module "control-plane" {
 
 - `source` (required): The source of the module, pointing to the GitHub repository.
 - `name` (required): The name of the control plane.
-- `token` (required): The control plane token for authentication.
 - `region` (required): The Azure region to deploy to.
 - `resource_group_name` (required): The name of the resource group where the control plane will be deployed.
+- `vault_name`(required): Vault name where the control plane secret token is stored.
+- `secret_id`(required): Secret identifier for the stored control plane token.
 - `storage_account_name` (required): The storage account name where configurations will be stored.
 - `locations` (required): The list of location module(s).
 - `private_package` (required): The name of the private package module for configuration.

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -69,6 +69,7 @@ module "location" {
 - `system_properties`: System properties to be assigned to the Location.
 - `java_home`: Overwrite JAVA_HOME definition.
 - `jvm_options`: Overwrite JAVA_HOME definition.
+- `enterprise_cloud.url`: Set up a forward proxy for the control plane.
 
 ### Control Plane
 
@@ -98,6 +99,7 @@ module "control-plane" {
 - `image`: Image of the control plane.
 - `description`: Description of the control plane.
 - `conf_share_file_name`: The name of the configuration object in the file share.
+- `enterprise_cloud.url`: Set up a forward proxy for the control plane.
 
 ## Usage
 

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -53,6 +53,9 @@ module "location" {
   subnet_name         = "default"
   size                = "Standard_A4_v2"
   engine              = "classic"
+  //enterprise_cloud    = {
+    //url = ""  // http://private-location-forward-proxy/gatling
+  //}
 }
 ```
 
@@ -85,6 +88,9 @@ module "control-plane" {
   storage_account_name = "storage-account-name"
   locations            = [module.location]
   private_package      = module.private-package
+  //enterprise_cloud    = {
+    //url = ""  // http://private-control-plane-forward-proxy/gatling
+  //}
 }
 ```
 

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -36,8 +36,13 @@ module "private-package" {
 ```
 
 - `source` (required): The source of the module, pointing to the GitHub repository.
-- `container_name` (required): The name of the control plane.
-- `storage_account_name` (required): SThe name of the storage account where the private package will be stored.
+- `container_name` (required): The name of the control plane container.
+- `storage_account_name` (required): The name of the storage account where the private package will be stored.
+- `upload.directory`: This directory temporarily stores uploaded JAR files.
+- `server.port`: The port on which the control plane is listening for private package uploads. The default is `8080`.
+- `server.bindAddress`: The network interface to bind to. The default is `0.0.0.0`, which means all available network IPv4 interfaces.
+- `server.certificate.path`: The server P12 certificate for secure connection without SSL reverse proxy.
+- `server.certificate.password`: The server P12 certificate password.
 
 ### Location
 

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -22,9 +22,10 @@ module "location" {
 module "control-plane" {
   source               = "git::git@github.com:gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "gatling-cp"
-  token                = "token"
   region               = "westeurope"
   resource_group_name  = "resource-group-name"
+  vault_name           = "vault-name"
+  secret_id            = "token-secret-identifier"
   storage_account_name = "storage-account-name"
   locations            = [module.location]
   private_package      = module.private-package

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -17,6 +17,9 @@ module "location" {
   subnet_name         = "default"
   //size                = "Standard_A4_v2"
   //engine              = "classic"
+  //enterprise_cloud    = {
+    //url = ""  // http://private-location-forward-proxy/gatling
+  //}
 }
 
 module "control-plane" {
@@ -29,4 +32,7 @@ module "control-plane" {
   storage_account_name = "storage-account-name"
   locations            = [module.location]
   private_package      = module.private-package
+  //enterprise_cloud    = {
+    //url = ""  // http://private-control-plane-forward-proxy/gatling
+  //}
 }


### PR DESCRIPTION
Motivation:
This PR enhances enterprise cloud support by introducing forward proxy configuration for control plane & locations, improving security with Azure Key Vault integration, and adding support for private package server configurations. It also focuses on maintainability by replacing deprecated storage_account_name from azurerm_storage_share.

Modifications:
- Add enterprise cloud variables for forward proxy support on control plane & locations.
- Handle CP token secret through Azure Key Vault.
- Update private package configuration.
- Replace deprecated storage_account_name from azurerm_storage_share with storage_account_id.
- Replace gatling_storage_share.id argument in azurerm_storage_share_file with gatling_storage_share.url.