### PR TITLE
[Terraform - AWS] chore:  Add location auto_associate_public_ipv4, ami_id, sys props & CP ecs task cpu & mem vars

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -24,4 +24,6 @@ module "ecs" {
   extra_content          = var.extra_content
   token_secret_arn       = var.token_secret_arn
   cloudWatch_logs        = var.cloudWatch_logs
+  task_cpu               = var.task_cpu
+  task_memory            = var.task_memory
 }

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -32,8 +32,8 @@ resource "aws_ecs_task_definition" "gatling_task" {
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = var.ecs_tasks_iam_role_arn
   execution_role_arn       = var.ecs_tasks_iam_role_arn
-  cpu                      = "1024"
-  memory                   = "3072"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
 
   container_definitions = jsonencode([
     {

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -70,3 +70,14 @@ variable "token_secret_arn" {
   type        = string
   description = "Secret Token ARN of the control plane"
 }
+
+
+variable "task_cpu" {
+  type        = string
+  description = "ECS task definition CPU."
+}
+
+variable "task_memory" {
+  type        = string
+  description = "ECS task definition Memory."
+}

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -79,3 +79,15 @@ variable "token_secret_arn" {
   type        = string
   description = "Control plane secret token ARN."
 }
+
+variable "task_cpu" {
+  type        = string
+  description = "ECS task definition CPU."
+  default     = "1024"
+}
+
+variable "task_memory" {
+  type        = string
+  description = "ECS task definition Memory."
+  default     = "3072"
+}

--- a/terraform/aws/location/main.tf
+++ b/terraform/aws/location/main.tf
@@ -8,16 +8,19 @@ locals {
     ami : {
       type : var.ami_type,
       java : var.java_version
+      id  : var.ami_id
     },
     subnets : var.subnet_ids,
     security-groups : var.security_group_ids,
     instance-type : var.instance_type,
     spot : var.spot,
+    auto-associate-public-ipv4: var.auto_associate_public_ipv4,
     elastic-ips : var.elastic_ips,
     profile_name : var.profile_name,
     iam-instance-profile : var.iam_instance_profile,
     tags : var.tags,
     tags-for : var.tags_for,
+    system-properties : var.system_properties,
     java-home : var.java_home,
     jvm-options : var.jvm_options,
     enterprise-cloud : var.enterprise_cloud

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -39,6 +39,12 @@ variable "ami_type" {
   default     = "certified"
 }
 
+variable "ami_id" {
+  type        = string
+  description = "Custom AMI id of the location."
+  default     = ""
+}
+
 variable "java_version" {
   type        = string
   description = "Java version of the location."
@@ -54,6 +60,12 @@ variable "subnet_ids" {
 variable "security_group_ids" {
   type        = list(string)
   description = "Security group ids of the location."
+}
+
+variable "auto_associate_public_ipv4" {
+  type        = bool
+  description = "Automatically associate a public IPv4."
+  default     = true
 }
 
 variable "elastic_ips" {

--- a/terraform/examples/AWS-private-location/README.md
+++ b/terraform/examples/AWS-private-location/README.md
@@ -35,10 +35,10 @@ module "location" {
   region             = "eu-west-1"
   subnet_ids         = ["subnet-a", "subnet-b"]
   security_group_ids = ["sg-id"]
-  instance_type      = "c7i.xlarge"
-  engine             = "classic"
+  //instance_type      = "c7i.xlarge"
+  //engine             = "classic"
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-location-forward-proxy/gatling"
   //}
 }
 ```
@@ -50,9 +50,11 @@ module "location" {
 - `security_group_ids` (required): List of security group IDs to be used.
 - `instance_type`: Instance type of the location.
 - `engine`: Engine of the location determining the compatible package formats (JavaScript or JVM).
+- `auto_associate_public_ipv4`: Automatically associate a public IPv4.
 - `elastic_ips`: Assign elastic IPs to your Locations.
 - `description`: Description of the location.
 - `ami_type`: AMI type of the location.
+- `ami_id`: Custom AMI id of the location.
 - `java_version`: Java version of the location.
 - `spot`: Flag to enable spot instances.
 - `profile_name`: Profile name to be assigned to the Location.
@@ -79,7 +81,7 @@ module "control-plane" {
   //cloudWatch_logs   = true
   //ecr               = false
   //enterprise_cloud  = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-control-plane-forward-proxy/gatling"
   //}
 }
 ```

--- a/terraform/examples/AWS-private-location/main.tf
+++ b/terraform/examples/AWS-private-location/main.tf
@@ -11,7 +11,7 @@ module "location" {
   //instance_type      = "c7i.xlarge"
   //engine             = "classic"
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-location-forward-proxy/gatling"
   //}
 }
 
@@ -25,6 +25,6 @@ module "control-plane" {
   //cloudWatch_logs    = true
   //ecr                = false
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-control-plane-forward-proxy/gatling"
   //}
 }

--- a/terraform/examples/AWS-private-package/README.md
+++ b/terraform/examples/AWS-private-package/README.md
@@ -53,7 +53,7 @@ module "location" {
   instance_type      = "c7i.xlarge"
   engine             = "classic"
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-location-forward-proxy/gatling"
   //}
 }
 ```
@@ -65,9 +65,11 @@ module "location" {
 - `security_group_ids` (required): List of security group IDs to be used.
 - `instance_type`: Instance type of the location.
 - `engine`: Engine of the location determining the compatible package formats (JavaScript or JVM).
+- `auto_associate_public_ipv4`: Automatically associate a public IPv4.
 - `elastic_ips`: Assign elastic IPs to your Locations.
 - `description`: Description of the location.
 - `ami_type`: AMI type of the location.
+- `ami_id`: Custom AMI id of the location.
 - `java_version`: Java version of the location.
 - `spot`: Flag to enable spot instances.
 - `profile_name`: Profile name to be assigned to the Location.
@@ -95,7 +97,7 @@ module "control-plane" {
   //cloudWatch_logs   = true
   //ecr               = false
   //enterprise_cloud  = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-control-plane-forward-proxy/gatling"
   //}
 }
 ```

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -16,7 +16,7 @@ module "location" {
   //instance_type      = "c7i.xlarge"
   //engine             = "classic"
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-location-forward-proxy/gatling"
   //}
 }
 
@@ -31,6 +31,6 @@ module "control-plane" {
   //cloudWatch_logs    = true
   //ecr                = false
   //enterprise_cloud = {
-    //url = ""  // http://private-control-plane-forward-proxy/gatling
+    //url = "http://private-control-plane-forward-proxy/gatling"
   //}
 }


### PR DESCRIPTION
Motivation:
Support new location conf option : auto_associate_public_ipv4 and improve location & control plane customization.

Modifications:
- Add location auto_associate_public_ipv4 var.
- Add missing ami_id to support custom AMIs and sys props var on location.
- Add customizable ECS task definition control plane container cpu and memory in order to support vertical scalability.