### PR TITLE
Feat: add github-actions checks and schedule day Sunday on Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/aws/cdk/typescript"
     schedule:
       interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "maven"
     directory: "/aws/cdk/java"
     schedule:
       interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Motivation:
Check automatically for latest github-actions.

Modification:
Add github-actions in Dependabot.