### PR TITLE
Feat: Add Helm Chart config reference token from an environment variable

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "1.0"
-version: 1.0.1
+version: 1.0.2
 name: enterprise-locations-packages
 description: Official Gatling Enterprise Helm chart for Private Locations & Packages
 home: https://gatling.io

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,67 +1,67 @@
-# Helm chart for Kubernetes Private Locations and Private Packages
+# Helm Chart for Gatling Enterprise Private Locations & Private Packages
 
-This Helm Chart sets up the Kubernetes resources for Gatling Enterprise's Private Locations and Private Packages deployment. There are 3 sets of values: `controlPlane`,
-`privateLocations`, `privatePackage` with configurable parameters that can be used to customize the deployment.
+This Helm chart deploys Gatling Enterprise Private Locations and Private Packages to your Kubernetes cluster. It provides three main configuration sections—`controlPlane`, `privateLocations`, and `privatePackage`—to customize your setup.
 
 ## Prerequisites
 
-- Gatling Enterprise [account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/auth?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) with Private Locations enabled. To access this feature, please contact our [technical support](https://gatlingcorp.atlassian.net/servicedesk/customer/portal/8/group/12/create/59?summary=Private+Locations&description=Contact%20email%3A%20%3Cemail%3E%0A%0AHello%2C%20we%20would%20like%20to%20enable%20the%20private%20locations%20feature%20on%20our%20organization.).
-- Gatling Enterprise control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token).
-- Kubernetes Cluster: A running Kubernetes cluster (v1.19 or later) or [Minikube](https://minikube.sigs.k8s.io/docs/start/) installed locally.
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command-line tool.
-- [Helm](https://helm.sh/docs/intro/) 3+.
+- Gatling Enterprise [account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/auth?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) with Private Locations enabled. If you do not have this feature, contact [Gatling technical support](https://gatlingcorp.atlassian.net/servicedesk/customer/portal/8/group/12/create/59?summary=Private+Locations&description=Contact%20email%3A%20%3Cemail%3E%0A%0AHello%2C%20we%20would%20like%20to%20enable%20the%20private%20locations%20feature%20on%20our%20organization.).
+- A Gatling Enterprise control plane [token](https://docs.gatling.io/reference/install/cloud/private-locations/introduction/#token), stored in a Kubernetes Secret of type Opaque.
+- A running Kubernetes cluster (v1.19 or later), or a local [Minikube](https://minikube.sigs.k8s.io/docs/start/) environment.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [Helm](https://helm.sh/docs/intro/) installed.
 
 ## Installation
 
-1. Add the Gatling Helm Repository
+1. Add the Gatling Helm Repository:
 ```sh
 helm repo add gatling "https://helm.gatling.io"
 ```
 
-2. Update Helm Repositories
+2. Update local Helm repositories:
 ```sh
 helm repo update
 ```
 
-3. Search for Gatling charts. Optional: To list all versions of the Gatling charts, include the `--versions` flag:
+3. Search for Gatling charts: (Tip: Include the `--versions` flag to list all chart versions.)
 ```sh
 helm search repo gatling
 ```
 
-4. Review default configuration values & set your Gatling control plane token at `controlPlane.token` and other configuration values. Optional: To export specific chart version values, include the `--versions` flag:
+4. Review default values and create your Secret:
+- Export the default chart values:
 ```sh
 helm show values gatling/enterprise-locations-packages > values.yaml
 ```
+- Manually create a Kubernetes Opaque Secret containing your control plane token, then reference that Secret in your `values.yaml` under `controlPlane.env[].valueFrom.secretKeyRef`.
+- For guidance on creating Secrets and mounting them as environment variables, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret).
+- Tip: Use `--version <chart-version>` for a specific chart version when exporting or installing.
 
 > [!IMPORTANT]
-> For `privateLocations.job`, we're working at the job template spec level, rather than the job spec level. To get a closer look at the structure, refer to the example JSON job definition [here].(https://docs.gatling.io/reference/install/cloud/private-locations/kubernetes/configuration/#example-json-job-definition).
+> For `privateLocations.job`, this chart operates at the job template spec level, not the job spec level. See this example [JSON job definition](https://docs.gatling.io/reference/install/cloud/private-locations/kubernetes/configuration/#example-json-job-definition) for more details.
 
 > [!TIP]
-> When connecting to the cluster using HTTPS, if a custom truststore and/or keystore is needed, `KUBERNETES_TRUSTSTORE_FILE`, `KUBERNETES_TRUSTSTORE_PASSPHRASE` and/or `KUBERNETES_KEYSTORE_FILE`, `KUBERNETES_KEYSTORE_PASSPHRASE` environment variables should be set.
+> If you need to configure HTTPS communication with custom truststores/keystores, set the following environment variables accordingly:
+`KUBERNETES_TRUSTSTORE_FILE`, `KUBERNETES_TRUSTSTORE_PASSPHRASE` and/or `KUBERNETES_KEYSTORE_FILE`, `KUBERNETES_KEYSTORE_PASSPHRASE`.
 
 > [!TIP]
-> The control plane and location configurations allow for the setup of a forward proxy. To enable this, uncomment `enterpriseCloud.url` values in the configuration file for the control plane and/or location. Ensure the forward proxy is configured to rewrite the Host header to `api.gatling.io` to ensure proper functionality.
+> Both the Control Plane and Private Locations can be configured to use a forward proxy. Uncomment `enterpriseCloud.url` in your values.yaml and ensure the proxy rewrites the Host header to `api.gatling.io`.
 
-5. Install the Gatling Enterprise Helm Chart. Optional: To install specific chart version, include the `--versions` flag:
+5. Install the Helm chart: (Tip: Include the `--version <chart-version>` flag to install a specific version.)
 ```sh
 helm install gatling-hybrid gatling/enterprise-locations-packages --namespace gatling --values <yaml-file/url> or --set key1=val1,key2=val2
 ```
 
 ### Activate Private Packages:
 
-- In order to activate Private Packages feature, set `privatePackage.enabled` to `true`. Note: A persistent Volume Claim will be created automatically if type = 'filesystem'.
-
-> [!IMPORTANT]
-> By default, the Control Plane filesystem is selected as the storage option. Before activating a different solution, comment out the `privatePackage.persistentVolumeClaim` and the repository filesystem section.
+- To enable Private Packages, set `privatePackage.enabled` to `true`. By default, storage uses the Control Plane filesystem, creating a PersistentVolumeClaim if type = `filesystem`.
 
 ## Uninstallation
 
-1. Uninstall the Gatling Helm chart
+1. Remove the release:
 ```sh
 helm uninstall gatling-hybrid -n gatling
 ```
 
-2. Update Helm Repositories
+2. Remove the Gatling Helm repository (optional):
 ```sh
 helm repo remove gatling
 ```

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -1,6 +1,6 @@
 {{- define "configFileContent" -}}
 control-plane {
-  token = "{{ .Values.controlPlane.token }}"
+  token = ${?CONTROL_PLANE_TOKEN}
   description = "{{ .Values.controlPlane.description }}"
 {{- if .Values.controlPlane.enterpriseCloud }}
   enterprise-cloud = {

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,140 +1,166 @@
-# Number of replicas (instances) to deploy
 replicaCount: 1
-
-# Kubernetes namespace where resources will be deployed
+# Kubernetes namespace where resources will be created.
 namespace: gatling
 
+# ----------------------------------------------------------------------
+# CONTROL PLANE SETTINGS
+# ----------------------------------------------------------------------
 controlPlane:
-  # Name of the control plane deployment
+  # Name used for the Control Plane Deployment.
   name: gatling-cp
-  # Authentication token for the control plane
-  token: token
-  # Description of the control plane
+  # Human-readable description for the Control Plane.
   description: My K8s control plane description
   image:
-    # Docker image name for the control plane
+    # Docker image for the Control Plane container.
     name: gatlingcorp/control-plane:latest
-    # Image pull policy (Always, IfNotPresent, Never)
-    pullPolicy: IfNotPresent
-    # Image pull secrets for private registry (list of secrets)
+    # How to pull the image (Always, IfNotPresent, Never).
+    pullPolicy: Always
+    # List of existing Kubernetes Secrets to pull images from private registries.
     pullSecrets: []
-  # Additional labels to add to the deployment
+  # Additional labels to be added to the Control Plane Deployment resource.
   deploymentLabels: {}
-  # Additional labels to add to the pods
+  # Additional labels to be added to the Control Plane Pods.
   podLabels: {}
-  # List of init containers to run before the app containers
+  # List of init containers that run before the main Control Plane container starts.
   initContainers: []
-  # Environment variables to set in the container
-  env: []
-  # Command to override default entrypoint of the container
+  # Environment variables injected into the Control Plane container.
+  env:
+    # Referencing a Kubernetes Secret to retrieve the Control Plane token.
+    - name: CONTROL_PLANE_TOKEN # DO NOT CHANGE
+      valueFrom:
+        secretKeyRef:
+          name: gatling-enterprise
+          key: api-token
+  # Override the default container entrypoint command if needed.
   command: []
-  # Volumes to attach to the pod
+  # Defines volumes for the Pod (e.g., configMaps, secrets, persistent volumes).
   volumes: []
-  # Volume mounts for the container
+  # Mount points for the volumes specified above.
   volumeMounts: []
-  # Node selector to constrain pods to nodes with specific labels
+  # Constrains Pods to nodes that match these key-value labels.
   nodeSelector: {}
-  # Affinity rules for pod scheduling
+  # Affinity rules (e.g., nodeAffinity, podAffinity, or podAntiAffinity).
   affinity: {}
-  # Tolerations to allow pods to be scheduled on tainted nodes
+  # Tolerations let Pods be scheduled on nodes with matching taints.
   tolerations: {}
-  resources: # We recommend aligning resource requests with limits to maintain consistent performance
-    # Resource requests for the container
+  # Resource requests and limits for the Control Plane container.
+  # Align requests with limits for consistent performance.
+  resources:
     requests:
       memory: "1Gi"
       cpu: "1"
-    # Resource limits for the container
     limits:
       memory: "1Gi"
       cpu: "1"
-  # Security context for the pod or container
+  # Security context for running the container with specific privileges or user IDs.
   securityContext: {}
+  # Uncomment to specify a forward proxy for the Control Plane (if needed).
   #enterpriseCloud:
-    #url: "http://private-control-plane-forward-proxy/gatling" # Set up a forward proxy for the control plane
+    #url: "http://private-control-plane-forward-proxy/gatling"
 
+# ----------------------------------------------------------------------
+# PRIVATE LOCATIONS
+# ----------------------------------------------------------------------
 privateLocations:
-  - id: "prl_kubernetes"  # Unique identifier for the private location
-    description: "Private Location on Kubernetes"  # Description of the private location
-    type: "kubernetes"  # Type of the private location
-    engine: "classic" # Execution engine type (classic or javascript)
+  - id: "prl_kubernetes"           # Unique identifier for the private location
+    description: "Private Location on Kubernetes"  # Short description
+    type: "kubernetes"             # The type of private location
+    engine: "classic"              # The execution engine type (e.g., "classic", "javascript")
     image:
-      type: "certified" # Image type (certified or custom)
-      #java: "latest"  # Java version to use (optional if engine = java, noop if engine type = javascript)
+      type: "certified"           # Image type (certified or custom)
+      #java: "latest"             # For classic engine; no-op for javascript
       #image: "gatlingcorp/classic-openjdk:latest"  # Custom image name
-    #systemProperties: {}  # System properties for the JVM
+    #systemProperties: {}         # System properties for the JVM
     #javaHome: "/usr/lib/jvm/zulu"  # Java home path
-    #jvmOptions: ["-Xmx4G", "-Xms512M"]  # JVM options
-    #keepLoadGeneratorAlive: false  # Whether to keep the load generator alive (for debugging)
+    #jvmOptions: ["-Xmx4G", "-Xms512M"]
+    #keepLoadGeneratorAlive: false  # Whether to keep the load generator alive (for debugging - Do not forget to delete ghost pods.)
+    # Uncomment to specify a forward proxy for the Location (if needed).
     #enterpriseCloud:
-      #url: "http://location-forward-proxy/gatling"  # Set up a forward proxy for your location configuration
+      #url: "http://location-forward-proxy/gatling"
 
-    # Working at the template spec level, not the job spec level.
-    # For a detailed structure, refer to this example JSON job definition:
-    # https://docs.gatling.io/reference/install/cloud/private-locations/kubernetes/configuration/#example-json-job-definition
+    # Kubernetes Job spec for the load generator
     job:
       spec:
         template:
           metadata:
-            annotations: {}  # Annotations to add to the pod
-            labels: {} # Labels to add to the pod
-            namespace: "{{ .Values.namespace }}"  # Namespace for the pod
+            # Additional annotation to be added to the Location Pods.
+            annotations: {}
+            # Additional labels to be added to the Location Pods.
+            labels: {}
+            # Kubernetes namespace where Locations will be created.
+            namespace: "{{ .Values.namespace }}"
           spec:
             containers:
-              - env: []  # Environment variables for the container
-                name: gatling-container  # Name of the container
-                resources: # We recommend aligning resource requests with limits to maintain consistent performance
-                  # Resource requests for the container
-                  limits": 
-                    memory: "2Gi"
-                    cpu: "2"
-                  # Resource limits for the container
+              - name: gatling-container
+                # Environment variables injected into the Location container(s).
+                env: []
+                # Resource requests and limits for the Location container(s).
+                # Align requests with limits for consistent performance.
+                resources:
                   requests:
                     memory: "2Gi"
                     cpu: "2"
-            # Security context for the pod or container
-            securityContext:
-              sysctls: []  # List of sysctls to set in the pod
-        ttlSecondsAfterFinished: 60  # Time (in seconds) to retain the job after completion
+                  limits:
+                    memory: "2Gi"
+                    cpu: "2"
+            # Security context for running the container with specific privileges or user IDs.
+            securityContext: {}
+        ttlSecondsAfterFinished: 60
 
+# ----------------------------------------------------------------------
+# PRIVATE PACKAGE SETTINGS
+# ----------------------------------------------------------------------
 privatePackage:
-  enabled: false  # Enable or disable the private package feature
+  # Enable or disable the private package repository feature.
+  enabled: false
   repository:
+    # Directory where files will be uploaded temporarily
     upload:
-      directory: "/tmp"  # Directory where files will be uploaded temporarily
+      directory: "/tmp"
     server:
-      port: 8080  # Port on which the repository server listens
-      #bindAddress: "0.0.0.0"  # Bind address for the server
-      #certificate:  # SSL certificate configuration
+      # Port on which the repository server listens
+      port: 8080
+      # Bind address for the server
+      #bindAddress: "0.0.0.0"
+      # SSL certificate configuration
+      #certificate:
         #path: "/path/to/certificate.p12"
         #password: "password"
     service:
-      type: NodePort # Service type on which you expose the control plane pod
+      # Service type on which you expose the control plane pod
+      type: NodePort
       ports:
-      - name: http # Name of the port on which the Service listens
-        protocol: TCP # Protocol of the port
-        port: 80 # Port on which the Service listens
-        targetPort: 8080 # Port on which the repository server listens
-    type: "filesystem"  # Choose the repository type: "filesystem", "aws", "azure", or "gcp"
+        - name: http
+          protocol: TCP
+          # Port on which the Service listens
+          port: 80
+          # Port on which the repository server listens
+          targetPort: 8080
+    # Repository backend: "filesystem", "aws", "azure", or "gcp".
+    type: "filesystem"
     configurations:
       aws:
-        bucket: "bucket-name"  # S3 bucket name
-        path: "folder/to/upload"  # Path within the S3 bucket
+        bucket: "bucket-name"
+        path: "folder/to/upload"
       azure:
-        storage-account: "storage-account-name"  # Azure storage account name
-        container: "container-name"  # Azure Blob Storage container name
-        path: "folder/to/upload"  # Path within the container
+        storage-account: "storage-account-name"
+        container: "container-name"
+        path: "folder/to/upload"
       gcp:
-        bucket: "bucket-name"  # GCS bucket name
-        path: "folder/to/upload"  # Path within the GCS bucket
-        project: "project-name"  # GCP project name
+        bucket: "bucket-name"
+        path: "folder/to/upload"
+        project: "project-name"
       filesystem:
-        directory: "/data/gatling-repository"  # Directory for filesystem storage
+        directory: "/data/gatling-repository"
         location:
-          download-base-url: "http://www.example.com:8080"  # Base URL for downloading packages
-  # PersistentVolumeClaim configuration (only if you're using filesystem repository)
-  persistentVolumeClaim:  # Comment out if you do not intend to use a repository.type = filesystem
-    storageClassName: ""  # Storage class name for the PVC
-    volumeMode: Filesystem  # Volume mode (Filesystem or Block)
-    accessModes: ["ReadWriteOnce"]  # Access modes for the PVC
-    storage: 5Gi  # Requested storage size
-    selector: {}  # Selector to match an existing PV (optional)
+          download-base-url: "http://www.example.com:8080"
+
+  # PersistentVolumeClaim configuration — only required if using 'repository.type = filesystem'.
+  persistentVolumeClaim:
+    # Storage class name for the PVC
+    storageClassName: ""
+    volumeMode: Filesystem
+    accessModes: ["ReadWriteOnce"]
+    storage: 5Gi
+    # Selector to match an existing PV (optional)
+    selector: {}


### PR DESCRIPTION
Motivation:
Securely storing control plane token as Kubernetes secret.

Modifications:
- Changed configuration in order to reference control plane token as environment variable.
- Add sample snippet mounting secret as environment variable on the control plane container.