### PR TITLE
Feat: Helm support for linking SA with Cloud specific permissions

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -4,6 +4,11 @@ version: 1.0.2
 name: enterprise-locations-packages
 description: Official Gatling Enterprise Helm chart for Private Locations & Packages
 home: https://gatling.io
+maintainers:
+  - name: "Karim Atwa"
+    email: "katwa@gatling.io"
+sources:
+  - "https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/helm-chart"
 keywords:
   - load-testing
   - smoke-testing

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -59,6 +59,16 @@ control-plane {
       tags = {{ toJson .tags }}
       tags-for = {{ toJson .tagsFor }}
     {{- end }}
+    {{- if eq .type "azure" }}
+      region = "{{ .region }}"
+      size = "{{ .size }}"
+      image = {{ toJson .image }}
+      subscription = "{{ .subscription }}"
+      network-id = "{{ .networkId }}"
+      subnet-name = "{{ .subnetName }}"
+      associate-public-ip = {{ toJson .associatePublicIp }}
+      tags = {{ toJson .tags }}
+    {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
       system-properties = {{ toJson .systemProperties }}
     {{- if .javaHome }}

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -12,17 +12,6 @@ control-plane {
   locations = [
   {{- range .Values.privateLocations }}
     {
-      id = "{{ .id }}"
-      description = "{{ .description }}"
-      type = "{{ .type }}"
-      namespace = "{{ $.Values.namespace }}"
-      engine = "{{ .engine }}"
-      image = {{ toJson .image }}
-      system-properties = {{ toJson .systemProperties }}
-    {{- if .javaHome }}
-      java-home = "{{ .javaHome }}"
-    {{- end }}
-      jvm-options = {{ toJson .jvmOptions }}
     {{- if .enterpriseCloud }}
       enterprise-cloud = {
       {{- if .enterpriseCloud.url }}
@@ -30,7 +19,14 @@ control-plane {
       {{- end }}
       }
     {{- end }}
-    {{- with .job }}
+      id = "{{ .id }}"
+      description = "{{ .description }}"
+      type = "{{ .type }}"
+      engine = "{{ .engine }}"
+    {{- if eq .type "kubernetes" }}
+      namespace = "{{ $.Values.namespace }}"
+      image = {{ toJson .image }}
+      {{- with .job }}
       job = {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -43,8 +39,32 @@ control-plane {
             "ttlSecondsAfterFinished": {{ .spec.ttlSecondsAfterFinished }}
         }
       }
+      {{- end }}
+    {{ end }}
+    {{- if eq .type "aws" }}
+      region = "{{ .region }}"
+      ami = {{ toJson .ami }}
+      security-groups = {{ toJson .securityGroups }}
+      instance-type = "{{ .instanceType }}"
+      spot = {{ toJson .spot }}
+      subnets = {{ toJson .subnets }}
+      auto-associate-public-ipv4 = {{ toJson .autoAssociatePublicIPv4 }}
+      elastic-ips = {{ toJson .elasticIps }}
+      {{- if .profileName }}
+      profile-name = "{{ .profileName }}"
+      {{- end }}
+      {{- if .iamInstanceProfile }}
+      iam-instance-profile = "{{ .iamInstanceProfile }}"
+      {{- end }}
+      tags = {{ toJson .tags }}
+      tags-for = {{ toJson .tagsFor }}
     {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
+      system-properties = {{ toJson .systemProperties }}
+    {{- if .javaHome }}
+      java-home = "{{ .javaHome }}"
+    {{- end }}
+      jvm-options = {{ toJson .jvmOptions }}
     }
   {{- end }}
   ]

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -22,9 +22,9 @@ control-plane {
       id = "{{ .id }}"
       description = "{{ .description }}"
       type = "{{ .type }}"
-      engine = "{{ .engine }}"
     {{- if eq .type "kubernetes" }}
       namespace = "{{ $.Values.namespace }}"
+      engine = "{{ .engine }}"
       image = {{ toJson .image }}
       {{- with .job }}
       job = {
@@ -43,6 +43,7 @@ control-plane {
     {{ end }}
     {{- if eq .type "aws" }}
       region = "{{ .region }}"
+      engine = "{{ .engine }}"
       ami = {{ toJson .ami }}
       security-groups = {{ toJson .securityGroups }}
       instance-type = "{{ .instanceType }}"
@@ -60,7 +61,8 @@ control-plane {
       tags-for = {{ toJson .tagsFor }}
     {{- end }}
     {{- if eq .type "azure" }}
-      region = "{{ .region }}"
+      region = "{{ .region }}
+      engine = "{{ .engine }}""
       size = "{{ .size }}"
       image = {{ toJson .image }}
       subscription = "{{ .subscription }}"
@@ -68,6 +70,14 @@ control-plane {
       subnet-name = "{{ .subnetName }}"
       associate-public-ip = {{ toJson .associatePublicIp }}
       tags = {{ toJson .tags }}
+    {{- end }}
+    {{- if eq .type "gcp" }}
+      zone = "{{ .zone }}"
+      project = "{{ .project }}"
+      {{- if .instanceTemplate }}
+      instance-template = "{{ .instanceTemplate }}"
+      {{- end }}
+      machine = {{ toJson .machine }}
     {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
       system-properties = {{ toJson .systemProperties }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       labels:
+      {{- if .Values.controlPlane.AzureClientID }}
+        azure.workload.identity/use: "true"
+      {{ end }}
         app.kubernetes.io/name: {{ .Values.controlPlane.name }}
       {{- with .Values.controlPlane.podLabels }}
         {{ toYaml . | nindent 8 }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -9,3 +9,6 @@ metadata:
   {{- if .Values.controlPlane.AWSroleARN }}
     eks.amazonaws.com/role-arn: "{{ .Values.controlPlane.AWSroleARN }}"
   {{ end }}
+  {{- if .Values.controlPlane.AzureClientID }}
+    azure.workload.identity/client-id: "{{ .Values.controlPlane.AzureClientID }}"
+  {{ end }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -12,3 +12,6 @@ metadata:
   {{- if .Values.controlPlane.AzureClientID }}
     azure.workload.identity/client-id: "{{ .Values.controlPlane.AzureClientID }}"
   {{ end }}
+  {{- if .Values.controlPlane.GCPServiceAccount }}
+    iam.gke.io/gcp-service-account: "{{ .Values.controlPlane.GCPServiceAccount }}"
+  {{ end }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: "{{ .Values.namespace }}"
   labels:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+  {{- if .Values.controlPlane.AWSroleARN }}
+    eks.amazonaws.com/role-arn: "{{ .Values.controlPlane.AWSroleARN }}"
+  {{ end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -57,11 +57,13 @@ controlPlane:
   # Uncomment to specify a forward proxy for the Control Plane (if needed).
   #enterpriseCloud:
     #url: "http://private-control-plane-forward-proxy/gatling"
-
+  #AWSroleARN: "arn:aws:iam::339713180729:role/EKS-EC2-Spawn-Role" # Optional AWS IAM role ARN for the Control Plane, used to create AWS Locations.
+  
 # ----------------------------------------------------------------------
 # PRIVATE LOCATIONS
 # ----------------------------------------------------------------------
 privateLocations:
+  # Kubernetes Location
   - id: "prl_kubernetes"           # Unique identifier for the private location
     description: "Private Location on Kubernetes"  # Short description
     type: "kubernetes"             # The type of private location
@@ -77,7 +79,6 @@ privateLocations:
     # Uncomment to specify a forward proxy for the Location (if needed).
     #enterpriseCloud:
       #url: "http://location-forward-proxy/gatling"
-
     # Kubernetes Job spec for the load generator
     job:
       spec:
@@ -106,6 +107,33 @@ privateLocations:
             # Security context for running the container with specific privileges or user IDs.
             securityContext: {}
         ttlSecondsAfterFinished: 60
+  # AWS Location
+  #- id: "prl_kubernetes_aws"
+    #description: "Private Location on AWS"
+    #type: "aws"
+    #region: "eu-west-3"
+    #engine: "classic"
+    #ami:
+      #type: "certified"              # Options: certified, custom
+      #java = "latest"               # For classic engine; no-op for javascript
+      #id: "ami-id"   # Only needed for a custom AMI configuration
+    #securityGroups: ["sg-id"]
+    #instanceType: "c7i.xlarge"
+    #spot: false                      # Set to true if using spot instances
+    #subnets: ["subnet-a"]
+    #autoAssociatePublicIPv4: true    # Optional; default is true if omitted
+    #elasticIps: ["0.0.0.0", "0.0.0.0"]  # Optional; only if not using auto-association
+    #profileName: "my-aws-profile"      # Optional AWS CLI profile name
+    #iamInstanceProfile: "my-iam-instance-profile"  # Optional IAM instance profile
+    #tags:                            # Custom tags for all AWS resources
+      #ExampleKey: "ExampleValue"
+    #tagsFor:                         # Custom tags per resource type
+      #instance: {}
+      #volume: {}
+      #network-interface: {}
+    #systemProperties: {}
+    #javaHome: "/usr/lib/jvm/zulu"
+    #jvmOptions: ["-Xmx4G", "-Xms512M"]
 
 # ----------------------------------------------------------------------
 # PRIVATE PACKAGE SETTINGS

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -58,7 +58,8 @@ controlPlane:
   #enterpriseCloud:
     #url: "http://private-control-plane-forward-proxy/gatling"
   #AWSroleARN: "arn:aws:iam::339713180729:role/EKS-EC2-Spawn-Role" # Optional AWS IAM role ARN for the Control Plane, used to create AWS Locations.
-  
+  #AzureClientID: "65c5547a-b6a7-4ad7-abef-166ba4cef160" # Optional Azure Identity client ID for the Control Plane, used to create Azure Locations.
+
 # ----------------------------------------------------------------------
 # PRIVATE LOCATIONS
 # ----------------------------------------------------------------------
@@ -125,8 +126,7 @@ privateLocations:
     #elasticIps: ["0.0.0.0", "0.0.0.0"]  # Optional; only if not using auto-association
     #profileName: "my-aws-profile"      # Optional AWS CLI profile name
     #iamInstanceProfile: "my-iam-instance-profile"  # Optional IAM instance profile
-    #tags:                            # Custom tags for all AWS resources
-      #ExampleKey: "ExampleValue"
+    #tags: {}                           # Custom tags for all AWS resources
     #tagsFor:                         # Custom tags per resource type
       #instance: {}
       #volume: {}
@@ -134,7 +134,25 @@ privateLocations:
     #systemProperties: {}
     #javaHome: "/usr/lib/jvm/zulu"
     #jvmOptions: ["-Xmx4G", "-Xms512M"]
-
+  #- id: "prl_azure"
+    #description: "Private Location on Azure"
+    #type: "azure"
+    #region: "westeurope"             # Azure region (location name)
+    #size: "Standard_A4_v2"           # Virtual machine size (as per Azure CLI)
+    #engine: "classic"
+    #image:
+      #type: "certified"              # Options: certified, custom
+      #java: "latest"                 # For classic engine; ignored for javascript
+      # For custom images, you could alternatively set an image path:
+      #image: "/subscriptions/.../customImages/images/<MyImage>"
+    #subscription: "<SubscriptionId>" # Azure subscription ID
+    #networkId: "/subscriptions/<SubscriptionId>/resourceGroups/<ResouceGroup>/providers/Microsoft.Network/virtualNetworks/<VirtualNetwork>"
+    #subnetName: "subnet-name"        # Subnet name within the specified virtual network
+    #associatePublicIp: true          # Whether to associate a public IP
+    #tags: {}                         # Virtual machine tags
+    #systemProperties: {}
+    #javaHome: "/usr/lib/jvm/zulu"
+    #jvmOptions: ["-Xmx4G", "-Xms512M"]
 # ----------------------------------------------------------------------
 # PRIVATE PACKAGE SETTINGS
 # ----------------------------------------------------------------------

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -57,8 +57,9 @@ controlPlane:
   # Uncomment to specify a forward proxy for the Control Plane (if needed).
   #enterpriseCloud:
     #url: "http://private-control-plane-forward-proxy/gatling"
-  #AWSroleARN: "arn:aws:iam::339713180729:role/EKS-EC2-Spawn-Role" # Optional AWS IAM role ARN for the Control Plane, used to create AWS Locations.
-  #AzureClientID: "65c5547a-b6a7-4ad7-abef-166ba4cef160" # Optional Azure Identity client ID for the Control Plane, used to create Azure Locations.
+  #AWSroleARN: "arn:aws:iam::<AccountId>:role/<Role-Name>" # Optional AWS IAM role ARN for the Control Plane, used to access AWS resources.
+  #AzureClientID: "<ClientId>" # Optional Azure Identity client ID for the Control Plane, used to access Azure resources.
+  #GCPServiceAccount: "<ServiceAccount>" # Optional GCP service account for the Control Plane, used to access GCP resources.
 
 # ----------------------------------------------------------------------
 # PRIVATE LOCATIONS
@@ -108,51 +109,80 @@ privateLocations:
             # Security context for running the container with specific privileges or user IDs.
             securityContext: {}
         ttlSecondsAfterFinished: 60
-  # AWS Location
-  #- id: "prl_kubernetes_aws"
-    #description: "Private Location on AWS"
-    #type: "aws"
-    #region: "eu-west-3"
-    #engine: "classic"
-    #ami:
-      #type: "certified"              # Options: certified, custom
-      #java = "latest"               # For classic engine; no-op for javascript
-      #id: "ami-id"   # Only needed for a custom AMI configuration
-    #securityGroups: ["sg-id"]
-    #instanceType: "c7i.xlarge"
-    #spot: false                      # Set to true if using spot instances
-    #subnets: ["subnet-a"]
-    #autoAssociatePublicIPv4: true    # Optional; default is true if omitted
-    #elasticIps: ["0.0.0.0", "0.0.0.0"]  # Optional; only if not using auto-association
-    #profileName: "my-aws-profile"      # Optional AWS CLI profile name
-    #iamInstanceProfile: "my-iam-instance-profile"  # Optional IAM instance profile
-    #tags: {}                           # Custom tags for all AWS resources
-    #tagsFor:                         # Custom tags per resource type
-      #instance: {}
-      #volume: {}
-      #network-interface: {}
-    #systemProperties: {}
-    #javaHome: "/usr/lib/jvm/zulu"
-    #jvmOptions: ["-Xmx4G", "-Xms512M"]
-  #- id: "prl_azure"
-    #description: "Private Location on Azure"
-    #type: "azure"
-    #region: "westeurope"             # Azure region (location name)
-    #size: "Standard_A4_v2"           # Virtual machine size (as per Azure CLI)
-    #engine: "classic"
-    #image:
-      #type: "certified"              # Options: certified, custom
-      #java: "latest"                 # For classic engine; ignored for javascript
-      # For custom images, you could alternatively set an image path:
-      #image: "/subscriptions/.../customImages/images/<MyImage>"
-    #subscription: "<SubscriptionId>" # Azure subscription ID
-    #networkId: "/subscriptions/<SubscriptionId>/resourceGroups/<ResouceGroup>/providers/Microsoft.Network/virtualNetworks/<VirtualNetwork>"
-    #subnetName: "subnet-name"        # Subnet name within the specified virtual network
-    #associatePublicIp: true          # Whether to associate a public IP
-    #tags: {}                         # Virtual machine tags
-    #systemProperties: {}
-    #javaHome: "/usr/lib/jvm/zulu"
-    #jvmOptions: ["-Xmx4G", "-Xms512M"]
+  # AWS Private Location configuration
+  #- id: "prl_kubernetes_aws"               # Unique identifier for the AWS private location
+  #  description: "Private Location on AWS"  # Brief description of the AWS location
+  #  type: "aws"                             # Location type (AWS)
+  #  region: "eu-west-3"                     # AWS region where the instance will run
+  #  engine: "classic"                       # Execution engine type (e.g., "classic" or "javascript")
+  #  ami:
+  #    type: "certified"                     # AMI image type: "certified" for default or "custom" for user-provided images
+  #     #java: "latest"                      # (Optional) Java version for the classic engine; no effect for javascript engine
+  #     #id: "ami-id"                        # (Required if using custom AMI) Custom AMI identifier
+  #  securityGroups: ["sg-id"]               # List of AWS security group IDs to attach to the instance
+  #  instanceType: "c7i.xlarge"              # AWS instance type specification
+  #  #spot: false                          # (Optional) Set to true to use spot instances instead of on-demand
+  #  subnets: ["subnet-a"]                   # List of subnet IDs for network placement
+  #  #autoAssociatePublicIPv4: true        # (Optional) Whether to automatically assign a public IPv4; defaults to true if omitted
+  #  #elasticIps: ["0.0.0.0", "0.0.0.0"]     # (Optional) Specify static elastic IPs if public IP auto-association is disabled
+  #  #profileName: "my-aws-profile"          # (Optional) AWS CLI profile to use for the API calls
+  #  #iamInstanceProfile: "my-iam-instance-profile"  # (Optional) IAM instance profile name for the instance
+  #  #tags: {}                             # (Optional) Global tags applied to all AWS resources created
+  #  #tagsFor:                             # (Optional) Specific tags for different AWS resource types
+  #    #instance: {}
+  #    #volume: {}
+  #    #network-interface: {}
+  #  #systemProperties: {}                 # (Optional) Additional system properties for the AWS location
+  #  #javaHome: "/usr/lib/jvm/zulu"         # (Optional) Custom JAVA_HOME path
+  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]     # (Optional) JVM options for tuning performance
+  #
+  # Azure Private Location configuration
+  #- id: "prl_azure"                       # Unique identifier for the Azure private location
+  #  description: "Private Location on Azure"  # Brief description of the Azure location
+  #  type: "azure"                           # Location type (Azure)
+  #  region: "westeurope"                     # Azure region (location name)
+  #  size: "Standard_A4_v2"                   # Virtual machine size according to Azure specifications
+  #  engine: "classic"                        # Execution engine type
+  #  image:
+  #    type: "certified"                      # Image type: "certified" for default, "custom" for user-provided
+  #    #java: "latest"                       # (Optional) Java version setting for the classic engine; ignored for javascript engine
+  #    #image: "/subscriptions/.../customImages/images/<MyImage>"  # (Optional) Custom image path for user-provided images
+  #  subscription: "<SubscriptionId>"         # Azure subscription ID for resource management
+  #  networkId: "/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VirtualNetwork>"
+  #                                           # Full resource ID of the virtual network to be used
+  #  subnetName: "subnet-name"                # Name of the subnet within the specified virtual network
+  #  #associatePublicIp: true                # (Optional) Whether to assign a public IP to the VM
+  #  #tags: {}                               # (Optional) Custom tags for the Azure VM
+  #  #systemProperties: {}                   # (Optional) Additional system properties for the Azure location
+  #  #javaHome: "/usr/lib/jvm/zulu"           # (Optional) Custom JAVA_HOME path
+  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]       # (Optional) Custom JVM options for performance tuning
+  #
+  # GCP Private Location configuration
+  #- id: "prl_gcp"                         # Unique identifier for the GCP private location
+  #  description: "Private Location on GCP"  # Brief description of the GCP location
+  #  type: "gcp"                             # Location type (GCP)
+  #  project: "project-id"                   # Your GCP project ID
+  #  zone: "europe-west3-a"                  # GCP zone where the instance will be deployed
+  #  #instanceTemplate: "example-template" # (Optional) Pre-defined instance template to use instead of manual configuration
+  #  machine:
+  #    type: "c3-highcpu-4"                  # GCP machine type; refer to gcloud for available options
+  #    engine: "classic"                     # Execution engine type (e.g., "classic" or "javascript")
+  #    #preemptible: false                  # (Optional) Set to true for using preemptible instances to reduce costs
+  #    image:
+  #      type: "certified"                   # Image type: "certified" for default or "custom" for user-provided images
+  #      #java: "latest"                    # (Optional) Java version for the image if required by your workload
+  #      #project: "project-id"             # (Optional) Specify project if using a custom image from a different project
+  #      #family: "image-family"            # (Optional) Image family to select the appropriate image version
+  #    disk:
+  #      sizeGb: 20                          # Disk size in GB; ensure it meets your storage needs
+  #    #network-interface:                   # (Optional) Network interface configuration for advanced networking setups
+  #      #network: "gatling-network"        # (Optional) Name of the GCP network to use
+  #      #subnetwork: "gatling-subnetwork-europe-west3"  # (Optional) Specific subnetwork within the network
+  #      #with-external-ip: true            # (Optional) Set to true to assign an external IP address
+  #  #systemProperties: {}                  # (Optional) Additional system properties for the GCP location
+  #  #javaHome: "/usr/lib/jvm/zulu"          # (Optional) Custom JAVA_HOME path
+  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]      # (Optional) JVM options for performance tuning
+    
 # ----------------------------------------------------------------------
 # PRIVATE PACKAGE SETTINGS
 # ----------------------------------------------------------------------

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -65,16 +65,16 @@ controlPlane:
 # PRIVATE LOCATIONS
 # ----------------------------------------------------------------------
 privateLocations:
-  # Kubernetes Location
-  - id: "prl_kubernetes"           # Unique identifier for the private location
+  # Kubernetes Private Location configuration
+  - id: "prl_kubernetes"            # Unique identifier for the private location
     description: "Private Location on Kubernetes"  # Short description
-    type: "kubernetes"             # The type of private location
-    engine: "classic"              # The execution engine type (e.g., "classic", "javascript")
+    type: "kubernetes"              # The type of private location
+    engine: "classic"               # The execution engine type (e.g., "classic", "javascript")
     image:
-      type: "certified"           # Image type (certified or custom)
-      #java: "latest"             # For classic engine; no-op for javascript
+      type: "certified"             # Image type (certified or custom)
+      #java: "latest"               # For classic engine; no-op for javascript
       #image: "gatlingcorp/classic-openjdk:latest"  # Custom image name
-    #systemProperties: {}         # System properties for the JVM
+    #systemProperties: {}           # System properties for the JVM
     #javaHome: "/usr/lib/jvm/zulu"  # Java home path
     #jvmOptions: ["-Xmx4G", "-Xms512M"]
     #keepLoadGeneratorAlive: false  # Whether to keep the load generator alive (for debugging - Do not forget to delete ghost pods.)
@@ -110,7 +110,7 @@ privateLocations:
             securityContext: {}
         ttlSecondsAfterFinished: 60
   # AWS Private Location configuration
-  #- id: "prl_kubernetes_aws"               # Unique identifier for the AWS private location
+  #- id: "prl_kubernetes_aws"                # Unique identifier for the AWS private location
   #  description: "Private Location on AWS"  # Brief description of the AWS location
   #  type: "aws"                             # Location type (AWS)
   #  region: "eu-west-3"                     # AWS region where the instance will run
@@ -121,67 +121,67 @@ privateLocations:
   #     #id: "ami-id"                        # (Required if using custom AMI) Custom AMI identifier
   #  securityGroups: ["sg-id"]               # List of AWS security group IDs to attach to the instance
   #  instanceType: "c7i.xlarge"              # AWS instance type specification
-  #  #spot: false                          # (Optional) Set to true to use spot instances instead of on-demand
+  #  #spot: false                            # (Optional) Set to true to use spot instances instead of on-demand
   #  subnets: ["subnet-a"]                   # List of subnet IDs for network placement
-  #  #autoAssociatePublicIPv4: true        # (Optional) Whether to automatically assign a public IPv4; defaults to true if omitted
+  #  #autoAssociatePublicIPv4: true          # (Optional) Whether to automatically assign a public IPv4; defaults to true if omitted
   #  #elasticIps: ["0.0.0.0", "0.0.0.0"]     # (Optional) Specify static elastic IPs if public IP auto-association is disabled
   #  #profileName: "my-aws-profile"          # (Optional) AWS CLI profile to use for the API calls
   #  #iamInstanceProfile: "my-iam-instance-profile"  # (Optional) IAM instance profile name for the instance
-  #  #tags: {}                             # (Optional) Global tags applied to all AWS resources created
-  #  #tagsFor:                             # (Optional) Specific tags for different AWS resource types
+  #  #tags: {}                               # (Optional) Global tags applied to all AWS resources created
+  #  #tagsFor:                               # (Optional) Specific tags for different AWS resource types
   #    #instance: {}
   #    #volume: {}
   #    #network-interface: {}
-  #  #systemProperties: {}                 # (Optional) Additional system properties for the AWS location
-  #  #javaHome: "/usr/lib/jvm/zulu"         # (Optional) Custom JAVA_HOME path
+  #  #systemProperties: {}                   # (Optional) Additional system properties for the AWS location
+  #  #javaHome: "/usr/lib/jvm/zulu"          # (Optional) Custom JAVA_HOME path
   #  #jvmOptions: ["-Xmx4G", "-Xms512M"]     # (Optional) JVM options for tuning performance
   #
   # Azure Private Location configuration
-  #- id: "prl_azure"                       # Unique identifier for the Azure private location
-  #  description: "Private Location on Azure"  # Brief description of the Azure location
+  #- id: "prl_kubernetes_azure"              # Unique identifier for the Azure private location
+  #  description: "Private Location on Azure"# Brief description of the Azure location
   #  type: "azure"                           # Location type (Azure)
-  #  region: "westeurope"                     # Azure region (location name)
-  #  size: "Standard_A4_v2"                   # Virtual machine size according to Azure specifications
-  #  engine: "classic"                        # Execution engine type
+  #  region: "westeurope"                    # Azure region (location name)
+  #  size: "Standard_A4_v2"                  # Virtual machine size according to Azure specifications
+  #  engine: "classic"                       # Execution engine type
   #  image:
-  #    type: "certified"                      # Image type: "certified" for default, "custom" for user-provided
+  #    type: "certified"                     # Image type: "certified" for default, "custom" for user-provided
   #    #java: "latest"                       # (Optional) Java version setting for the classic engine; ignored for javascript engine
   #    #image: "/subscriptions/.../customImages/images/<MyImage>"  # (Optional) Custom image path for user-provided images
-  #  subscription: "<SubscriptionId>"         # Azure subscription ID for resource management
+  #  subscription: "<SubscriptionId>"        # Azure subscription ID for resource management
   #  networkId: "/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VirtualNetwork>"
-  #                                           # Full resource ID of the virtual network to be used
-  #  subnetName: "subnet-name"                # Name of the subnet within the specified virtual network
+  #                                          # Full resource ID of the virtual network to be used
+  #  subnetName: "subnet-name"               # Name of the subnet within the specified virtual network
   #  #associatePublicIp: true                # (Optional) Whether to assign a public IP to the VM
   #  #tags: {}                               # (Optional) Custom tags for the Azure VM
   #  #systemProperties: {}                   # (Optional) Additional system properties for the Azure location
-  #  #javaHome: "/usr/lib/jvm/zulu"           # (Optional) Custom JAVA_HOME path
-  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]       # (Optional) Custom JVM options for performance tuning
+  #  #javaHome: "/usr/lib/jvm/zulu"          # (Optional) Custom JAVA_HOME path
+  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]     # (Optional) Custom JVM options for performance tuning
   #
   # GCP Private Location configuration
-  #- id: "prl_gcp"                         # Unique identifier for the GCP private location
+  #- id: "prl_kubernetes_gcp"                # Unique identifier for the GCP private location
   #  description: "Private Location on GCP"  # Brief description of the GCP location
   #  type: "gcp"                             # Location type (GCP)
   #  project: "project-id"                   # Your GCP project ID
   #  zone: "europe-west3-a"                  # GCP zone where the instance will be deployed
-  #  #instanceTemplate: "example-template" # (Optional) Pre-defined instance template to use instead of manual configuration
+  #  #instanceTemplate: "example-template"   # (Optional) Pre-defined instance template to use instead of manual configuration
   #  machine:
   #    type: "c3-highcpu-4"                  # GCP machine type; refer to gcloud for available options
   #    engine: "classic"                     # Execution engine type (e.g., "classic" or "javascript")
-  #    #preemptible: false                  # (Optional) Set to true for using preemptible instances to reduce costs
+  #    #preemptible: false                   # (Optional) Set to true for using preemptible instances to reduce costs
   #    image:
   #      type: "certified"                   # Image type: "certified" for default or "custom" for user-provided images
-  #      #java: "latest"                    # (Optional) Java version for the image if required by your workload
-  #      #project: "project-id"             # (Optional) Specify project if using a custom image from a different project
-  #      #family: "image-family"            # (Optional) Image family to select the appropriate image version
+  #      #java: "latest"                     # (Optional) Java version for the image if required by your workload
+  #      #project: "project-id"              # (Optional) Specify project if using a custom image from a different project
+  #      #family: "image-family"             # (Optional) Image family to select the appropriate image version
   #    disk:
   #      sizeGb: 20                          # Disk size in GB; ensure it meets your storage needs
   #    #network-interface:                   # (Optional) Network interface configuration for advanced networking setups
-  #      #network: "gatling-network"        # (Optional) Name of the GCP network to use
+  #      #network: "gatling-network"         # (Optional) Name of the GCP network to use
   #      #subnetwork: "gatling-subnetwork-europe-west3"  # (Optional) Specific subnetwork within the network
-  #      #with-external-ip: true            # (Optional) Set to true to assign an external IP address
-  #  #systemProperties: {}                  # (Optional) Additional system properties for the GCP location
+  #      #with-external-ip: true             # (Optional) Set to true to assign an external IP address
+  #  #systemProperties: {}                   # (Optional) Additional system properties for the GCP location
   #  #javaHome: "/usr/lib/jvm/zulu"          # (Optional) Custom JAVA_HOME path
-  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]      # (Optional) JVM options for performance tuning
+  #  #jvmOptions: ["-Xmx4G", "-Xms512M"]     # (Optional) JVM options for performance tuning
     
 # ----------------------------------------------------------------------
 # PRIVATE PACKAGE SETTINGS


### PR DESCRIPTION
Motivation:
Access cloud specific resources from control plane/load generators in order to securely access storage service or spawn cloud load generators.

Modifications:
- Updated values.yaml to support optional IAM Role ARN/AzureClientID/GCPServiceAccount on the control plane.
- Added conditional K8s Service Account annotations.
- Added conditional `azure.workload.identity/use: "true"` to deployment template.
