### PR TITLE
Fix: private-package condition on Private Locations

### DIFF
--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -11,7 +11,7 @@ locals {
       description = "${var.description}"
       enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
       locations = [ %{for location in var.locations} ${jsonencode(location.conf)}, %{endfor} ]
-      %{if var.private-package != {} }repository = ${jsonencode(var.private-package.conf)}%{endif}
+      %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
       %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
     }
   EOF
@@ -67,13 +67,13 @@ resource "aws_ecs_task_definition" "gatling_task" {
       command : var.task.command
       cpu : 0
       essential : true
-      portMappings : var.private-package == {} ? [] : [
+      portMappings : length(var.private-package) > 0  ? [
         {
           containerPort : var.private-package.conf.server.port,
           hostPort : var.private-package.conf.server.port,
           protocol : "tcp"
         }
-      ]
+      ] : []
       workingDirectory : local.path
       secrets : local.ecs_secrets
       environment : var.task.environment
@@ -96,7 +96,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
       ]
     }
   ])
-  
+
   volume {
     name = local.volume_name
   }

--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -82,9 +82,9 @@ locals {
 
   iam_profile_name_statements = distinct([
     for location in var.locations : {
-      Sid    = "AllowPassRole_${location.conf.iam-instance-profile}"
-      Effect = "Allow"
-      Action = "iam:PassRole"
+      Sid      = "AllowPassRole_${location.conf.iam-instance-profile}"
+      Effect   = "Allow"
+      Action   = "iam:PassRole"
       Resource = "arn:aws:iam:${data.aws_caller_identity.current.account_id}:role/${location.conf.iam-instance-profile}"
     }
     if location.conf.iam-instance-profile != ""
@@ -129,7 +129,7 @@ resource "aws_iam_policy" "ec2_policy" {
 }
 
 resource "aws_iam_policy" "package_s3_policy" {
-  count = var.private-package == {} ? 0 : 1
+  count = length(var.private-package) > 0 ? 1 : 0
   name  = "${var.name}-package-s3-policy"
   policy = jsonencode({
     Version = "2012-10-17",
@@ -208,7 +208,7 @@ resource "aws_iam_role_policy_attachment" "ec2_policy_attachment" {
 }
 
 resource "aws_iam_role_policy_attachment" "package_s3_policy_attachment" {
-  count      = var.private-package == {} ? 0 : 1
+  count      = length(var.private-package) > 0 ? 1 : 0
   role       = aws_iam_role.gatling_role.name
   policy_arn = aws_iam_policy.package_s3_policy[0].arn
 }


### PR DESCRIPTION
Motivation:
Fix incorrect conditions for `private-package` on ECS module.

Modification:
- Replace `private-package` map check with map length.