### PR TITLE
fix: sanitize IAM elasticIP policy Sid

### DIFF
--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -51,7 +51,7 @@ locals {
   elastic_ip_statements_extra = distinct(flatten([
     for location in var.locations : [
       for elastic_ip in location.conf.elastic-ips : {
-        Sid    = "AllowElasticIP_${data.aws_eip.by_ip[elastic_ip].id}"
+        Sid    = "AllowElasticIP${replace(data.aws_eip.by_ip[elastic_ip].id, "-", "")}"
         Effect = "Allow"
         Action = [
           "ec2:AssociateAddress",


### PR DESCRIPTION
Motivation:
Fix issue with Elastic IP policies: `MalformedPolicyDocument: Statement IDs (SID) must be alpha-numeric`.

Modification:

- Sanitize `AllowElasticIP_${data.aws_eip.by_ip[elastic_ip].id}"` to `"AllowElasticIP${replace(data.aws_eip.by_ip[elastic_ip].id, "-", "")}"`