### PR TITLE
Fix: replace aws iam-instance-profile & profile-name from empty strin…

### DIFF
--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -87,7 +87,7 @@ locals {
       Action   = "iam:PassRole"
       Resource = "arn:aws:iam:${data.aws_caller_identity.current.account_id}:role/${location.conf.iam-instance-profile}"
     }
-    if location.conf.iam-instance-profile != ""
+    if location.conf.iam-instance-profile != null
   ])
 
   elastic_ip_statements = flatten([

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -89,13 +89,13 @@ variable "elastic-ips" {
 variable "profile-name" {
   description = "Profile name to be assigned to the Location."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "iam-instance-profile" {
   description = "IAM instance profile to be assigned to the Location."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
Motivation:
Fix SdkClientException: Profile file contained no credentials for profile

Modification:
Replace `iam-instance-profile` & `profile-name` default value from empty string to `null`.