### PR TITLE
Fix: replace address with elastic-ip on EIP resource ARN

### DIFF
--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -57,7 +57,7 @@ locals {
           "ec2:AssociateAddress",
           "ec2:DisassociateAddress",
         ]
-        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:address/${data.aws_eip.by_ip[elastic_ip].id}"
+        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:elastic-ip/${data.aws_eip.by_ip[elastic_ip].id}"
       }
     ]
   ]))


### PR DESCRIPTION
Motivation:
Fix permission to ec2:AssociateAddress on EIP resources.

Modification:
Replace `address` with `elastic-ip` on EIP resource ARN.