### PR TITLE
Feat/terraform gcp location defaults

### DIFF
--- a/terraform/examples/GCP-private-location/README.md
+++ b/terraform/examples/GCP-private-location/README.md
@@ -76,7 +76,7 @@ Sets up the control plane with configurations for networking, security, and stor
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "name"
+  name              = "<Name>"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"

--- a/terraform/examples/GCP-private-location/README.md
+++ b/terraform/examples/GCP-private-location/README.md
@@ -36,30 +36,30 @@ module "location" {
   id                = "prl_gcp"
   project           = "<ProjectId>"
   zone              = "<Zone>"
-  instance-template = "<InstanceTemplate>"
-  machine = {
-    type = "c3-highcpu-4"
-    # preemptible = false
-    engine = "classic"
-    image = {
-      type = "certified"
-      # java    = "latest"
-      # project = "<ProjectName>"
-      # family  = "<ImageFamily>"
-      # id      = "<ImageId>"
-    }
-    disk = {
-      sizeGb = 20
-    }
-    # network-interface = {
-    #   network          = "<Network>"
-    #   subnetwork       = "<SubNetwork>"
-    #   with-external-ip = true
-    # }
-  }
+  # instance-template = "<InstanceTemplate>"
+  # machine = {
+  #   type        = "c3-highcpu-4"
+  #   preemptible = false
+  #   engine      = "classic"
+  #   image = {
+  #     type    = "certified"
+  #     java    = "latest"
+  #     project = "<ProjectName>"
+  #     family  = "<ImageFamily>"
+  #     id      = "<ImageId>"
+  #   }
+  #   disk = {
+  #     sizeGb = 20
+  #   }
+  #   network-interface = {
+  #     network          = "<Network>"
+  #     subnetwork       = "<SubNetwork>"
+  #     with-external-ip = false
+  #   }
+  # }
   # system-properties = {}
-  # java-home = "/usr/lib/jvm/zulu"
-  # jvm-options = ["-Xmx4G", "-Xms512M"]
+  # java-home         = "/usr/lib/jvm/zulu"
+  # jvm-options       = ["-Xmx4G", "-Xms512M"]
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
@@ -76,19 +76,34 @@ Sets up the control plane with configurations for networking, security, and stor
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "<Name>"
+  name              = "name"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"
     network = "<Network>"
     # subnetwork         = "<SubNetwork>"
-    enable-external-ip = true
+    # enable-external-ip = true
   }
-  locations       = [module.location]
+  locations = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   command     = []
+  #   environment = []
+  # }
+  # compute = {
+  #   boot-disk-image            = "projects/cos-cloud/global/images/cos-stable-113-18244-85-49"
+  #   machine-type               = "e2-standard-2"
+  #   min-cpu-platform           = "<MinCpuPlatform>"
+  #   confidential-instance-type = "ConfidentialInstanceType"
+  #   shielded = {
+  #     enable-secure-boot          = true
+  #     enable-vtpm                 = true
+  #     enable-integrity-monitoring = true
+  #   }
+  #   confidential = {
+  #     enable        = false
+  #     instance-type = "e2-standard-2"
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/GCP-private-location/main.tf
+++ b/terraform/examples/GCP-private-location/main.tf
@@ -6,7 +6,7 @@ provider "google" {
 # Configure a GCP private location
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/configuration/#control-plane-configuration-file
 module "location" {
-  source            = "../../gcp/location"
+  source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/location"
   id                = "prl_gcp"
   project           = "<ProjectId>"
   zone              = "<Zone>"
@@ -43,7 +43,7 @@ module "location" {
 # Create a control plane based on GCP VM
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
-  source            = "../../gcp/control-plane"
+  source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
   name              = "name"
   token-secret-name = "<TokenSecretName>"
   network = {

--- a/terraform/examples/GCP-private-location/main.tf
+++ b/terraform/examples/GCP-private-location/main.tf
@@ -6,36 +6,34 @@ provider "google" {
 # Configure a GCP private location
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/configuration/#control-plane-configuration-file
 module "location" {
-  source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/location"
+  source            = "../../gcp/location"
   id                = "prl_gcp"
   project           = "<ProjectId>"
   zone              = "<Zone>"
-  instance-template = "<InstanceTemplate>"
-  machine = {
-    type = "c3-highcpu-4"
-    # preemptible = false
-    engine = "classic"
-    image = {
-      type = "certified"
-
-      
-      # java    = "latest"
-      # project = "<ProjectName>"
-      # family  = "<ImageFamily>"
-      # id      = "<ImageId>"
-    }
-    disk = {
-      sizeGb = 20
-    }
-    # network-interface = {
-    #   network          = "<Network>"
-    #   subnetwork       = "<SubNetwork>"
-    #   with-external-ip = true
-    # }
-  }
+  # instance-template = "<InstanceTemplate>"
+  # machine = {
+  #   type        = "c3-highcpu-4"
+  #   preemptible = false
+  #   engine      = "classic"
+  #   image = {
+  #     type    = "certified"
+  #     java    = "latest"
+  #     project = "<ProjectName>"
+  #     family  = "<ImageFamily>"
+  #     id      = "<ImageId>"
+  #   }
+  #   disk = {
+  #     sizeGb = 20
+  #   }
+  #   network-interface = {
+  #     network          = "<Network>"
+  #     subnetwork       = "<SubNetwork>"
+  #     with-external-ip = false
+  #   }
+  # }
   # system-properties = {}
-  # java-home = "/usr/lib/jvm/zulu"
-  # jvm-options = ["-Xmx4G", "-Xms512M"]
+  # java-home         = "/usr/lib/jvm/zulu"
+  # jvm-options       = ["-Xmx4G", "-Xms512M"]
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
@@ -45,20 +43,35 @@ module "location" {
 # Create a control plane based on GCP VM
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
-  source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
+  source            = "../../gcp/control-plane"
   name              = "name"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"
     network = "<Network>"
     # subnetwork         = "<SubNetwork>"
-    enable-external-ip = true
+    # enable-external-ip = true
   }
-  locations       = [module.location]
+  locations = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   command     = []
+  #   environment = []
+  # }
+  # compute = {
+  #   boot-disk-image            = "projects/cos-cloud/global/images/cos-stable-113-18244-85-49"
+  #   machine-type               = "e2-standard-2"
+  #   min-cpu-platform           = "<MinCpuPlatform>"
+  #   confidential-instance-type = "ConfidentialInstanceType"
+  #   shielded = {
+  #     enable-secure-boot          = true
+  #     enable-vtpm                 = true
+  #     enable-integrity-monitoring = true
+  #   }
+  #   confidential = {
+  #     enable        = false
+  #     instance-type = "e2-standard-2"
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/GCP-private-location/main.tf
+++ b/terraform/examples/GCP-private-location/main.tf
@@ -44,7 +44,7 @@ module "location" {
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "name"
+  name              = "<Name>"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"

--- a/terraform/examples/GCP-private-package/README.md
+++ b/terraform/examples/GCP-private-package/README.md
@@ -103,7 +103,7 @@ Sets up the control plane with configurations for networking, security, and stor
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "name"
+  name              = "<Name>"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"

--- a/terraform/examples/GCP-private-package/README.md
+++ b/terraform/examples/GCP-private-package/README.md
@@ -34,8 +34,20 @@ This module specifies the private package parameters for the control plane. It i
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/private-packages/#control-plane-server
 module "private-package" {
   source  = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/private-package"
-  bucket  = "<BucketName>"
   project = "<ProjectId>"
+  bucket  = "<BucketName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 ```
 
@@ -51,30 +63,30 @@ module "location" {
   id                = "prl_gcp"
   project           = "<ProjectId>"
   zone              = "<Zone>"
-  instance-template = "<InstanceTemplate>"
-  machine = {
-    type = "c3-highcpu-4"
-    # preemptible = false
-    engine = "classic"
-    image = {
-      type = "certified"
-      # java    = "latest"
-      # project = "<ProjectName>"
-      # family  = "<ImageFamily>"
-      # id      = "<ImageId>"
-    }
-    disk = {
-      sizeGb = 20
-    }
-    # network-interface = {
-    #   network          = "<Network>"
-    #   subnetwork       = "<SubNetwork>"
-    #   with-external-ip = true
-    # }
-  }
+  # instance-template = "<InstanceTemplate>"
+  # machine = {
+  #   type        = "c3-highcpu-4"
+  #   preemptible = false
+  #   engine      = "classic"
+  #   image = {
+  #     type    = "certified"
+  #     java    = "latest"
+  #     project = "<ProjectName>"
+  #     family  = "<ImageFamily>"
+  #     id      = "<ImageId>"
+  #   }
+  #   disk = {
+  #     sizeGb = 20
+  #   }
+  #   network-interface = {
+  #     network          = "<Network>"
+  #     subnetwork       = "<SubNetwork>"
+  #     with-external-ip = false
+  #   }
+  # }
   # system-properties = {}
-  # java-home = "/usr/lib/jvm/zulu"
-  # jvm-options = ["-Xmx4G", "-Xms512M"]
+  # java-home         = "/usr/lib/jvm/zulu"
+  # jvm-options       = ["-Xmx4G", "-Xms512M"]
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
@@ -91,20 +103,34 @@ Sets up the control plane with configurations for networking, security, and stor
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "<Name>"
+  name              = "name"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"
     network = "<Network>"
     # subnetwork         = "<SubNetwork>"
-    enable-external-ip = true
+    # enable-external-ip = true
   }
-  locations       = [module.location]
-  private-package = module.private-package
+  locations = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   command     = []
+  #   environment = []
+  # }
+  # compute = {
+  #   boot-disk-image            = "projects/cos-cloud/global/images/cos-stable-113-18244-85-49"
+  #   machine-type               = "e2-standard-2"
+  #   min-cpu-platform           = "<MinCpuPlatform>"
+  #   confidential-instance-type = "ConfidentialInstanceType"
+  #   shielded = {
+  #     enable-secure-boot          = true
+  #     enable-vtpm                 = true
+  #     enable-integrity-monitoring = true
+  #   }
+  #   confidential = {
+  #     enable        = false
+  #     instance-type = "e2-standard-2"
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/GCP-private-package/main.tf
+++ b/terraform/examples/GCP-private-package/main.tf
@@ -65,7 +65,7 @@ module "location" {
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "name"
+  name              = "<Name>"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"

--- a/terraform/examples/GCP-private-package/main.tf
+++ b/terraform/examples/GCP-private-package/main.tf
@@ -8,41 +8,53 @@ provider "google" {
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/private-packages/#control-plane-server
 module "private-package" {
   source  = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/private-package"
-  bucket  = "<BucketName>"
   project = "<ProjectId>"
+  bucket  = "<BucketName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 
 # Configure a GCP private location
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/configuration/#control-plane-configuration-file
 module "location" {
-  source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/location"
-  id                = "prl_gcp"
-  project           = "<ProjectId>"
-  zone              = "<Zone>"
-  instance-template = "<InstanceTemplate>"
-  machine = {
-    type = "c3-highcpu-4"
-    # preemptible = false
-    engine = "classic"
-    image = {
-      type = "certified"
-      # java    = "latest"
-      # project = "<ProjectName>"
-      # family  = "<ImageFamily>"
-      # id      = "<ImageId>"
-    }
-    disk = {
-      sizeGb = 20
-    }
-    # network-interface = {
-    #   network          = "<Network>"
-    #   subnetwork       = "<SubNetwork>"
-    #   with-external-ip = true
-    # }
-  }
+  source  = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/location"
+  id      = "prl_gcp"
+  project = "<ProjectId>"
+  zone    = "<Zone>"
+  # instance-template = "<InstanceTemplate>"
+  # machine = {
+  #   type        = "c3-highcpu-4"
+  #   preemptible = false
+  #   engine      = "classic"
+  #   image = {
+  #     type    = "certified"
+  #     java    = "latest"
+  #     project = "<ProjectName>"
+  #     family  = "<ImageFamily>"
+  #     id      = "<ImageId>"
+  #   }
+  #   disk = {
+  #     sizeGb = 20
+  #   }
+  #   network-interface = {
+  #     network          = "<Network>"
+  #     subnetwork       = "<SubNetwork>"
+  #     with-external-ip = false
+  #   }
+  # }
   # system-properties = {}
-  # java-home = "/usr/lib/jvm/zulu"
-  # jvm-options = ["-Xmx4G", "-Xms512M"]
+  # java-home         = "/usr/lib/jvm/zulu"
+  # jvm-options       = ["-Xmx4G", "-Xms512M"]
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
@@ -53,20 +65,34 @@ module "location" {
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/gcp/installation/
 module "control-plane" {
   source            = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/gcp/control-plane"
-  name              = "<Name>"
+  name              = "name"
   token-secret-name = "<TokenSecretName>"
   network = {
     zone    = "<Zone>"
     network = "<Network>"
     # subnetwork         = "<SubNetwork>"
-    enable-external-ip = true
+    # enable-external-ip = true
   }
-  locations       = [module.location]
-  private-package = module.private-package
+  locations = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   command     = []
+  #   environment = []
+  # }
+  # compute = {
+  #   boot-disk-image            = "projects/cos-cloud/global/images/cos-stable-113-18244-85-49"
+  #   machine-type               = "e2-standard-2"
+  #   min-cpu-platform           = "<MinCpuPlatform>"
+  #   confidential-instance-type = "ConfidentialInstanceType"
+  #   shielded = {
+  #     enable-secure-boot          = true
+  #     enable-vtpm                 = true
+  #     enable-integrity-monitoring = true
+  #   }
+  #   confidential = {
+  #     enable        = false
+  #     instance-type = "e2-standard-2"
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/gcp/control-plane/modules/virtual-machine/main.tf
+++ b/terraform/gcp/control-plane/modules/virtual-machine/main.tf
@@ -1,13 +1,13 @@
 locals {
-  conf_file_name = "control-plane.conf"
-  host_path      = "/etc/control-plane"
-  mount_path     = "/app/conf"
-  volume         = "-v ${local.host_path}/${local.conf_file_name}:${local.mount_path}/${local.conf_file_name}"
-  env_list       = concat(["-e CONTROL_PLANE_TOKEN=$CONTROL_PLANE_TOKEN"], lookup(var.container, "env", []))
-  env            = join(" ", local.env_list)
-  port           = length(var.private-package) > 0  ? "-p ${var.private-package.conf.server.port}:${var.private-package.conf.server.port}" : ""
-  command        = join(" ", var.container.command)
-  config_content = <<-EOF
+  conf_file_name   = "control-plane.conf"
+  host_path        = "/etc/control-plane"
+  mount_path       = "/app/conf"
+  volume           = "-v ${local.host_path}/${local.conf_file_name}:${local.mount_path}/${local.conf_file_name}"
+  environment_list = concat(["-e CONTROL_PLANE_TOKEN=$CONTROL_PLANE_TOKEN"], lookup(var.container, "environment", []))
+  environment      = join(" ", local.environment_list)
+  port             = length(var.private-package) > 0 ? "-p ${var.private-package.conf.server.port}:${var.private-package.conf.server.port}" : ""
+  command          = join(" ", var.container.command)
+  config_content   = <<-EOF
     control-plane {
       token = $${?CONTROL_PLANE_TOKEN}
       description = "${var.description}"
@@ -56,7 +56,7 @@ resource "google_compute_instance" "control_plane" {
     mkdir -p ${local.host_path}
     echo '${local.config_content}' | sudo tee ${local.host_path}/${local.conf_file_name}
 
-    sudo docker run -d --name ${var.name} ${local.env} ${local.volume} ${var.container.image} ${local.port} ${local.command}
+    sudo docker run -d --name ${var.name} ${local.environment} ${local.volume} ${var.container.image} ${local.port} ${local.command}
   EOF
 
   shielded_instance_config {

--- a/terraform/gcp/control-plane/modules/virtual-machine/main.tf
+++ b/terraform/gcp/control-plane/modules/virtual-machine/main.tf
@@ -5,7 +5,7 @@ locals {
   volume         = "-v ${local.host_path}/${local.conf_file_name}:${local.mount_path}/${local.conf_file_name}"
   env_list       = concat(["-e CONTROL_PLANE_TOKEN=$CONTROL_PLANE_TOKEN"], lookup(var.container, "env", []))
   env            = join(" ", local.env_list)
-  port           = var.private-package == {} ? "" : "-p ${var.private-package.conf.server.port}:${var.private-package.conf.server.port}" 
+  port           = length(var.private-package) > 0  ? "-p ${var.private-package.conf.server.port}:${var.private-package.conf.server.port}" : ""
   command        = join(" ", var.container.command)
   config_content = <<-EOF
     control-plane {
@@ -13,7 +13,7 @@ locals {
       description = "${var.description}"
       enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
       locations = [ %{for location in var.locations} ${jsonencode(location.conf)}, %{endfor} ]
-      %{if var.private-package != {}}repository = ${jsonencode(var.private-package.conf)}%{endif}
+      %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
       %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
     }
   EOF

--- a/terraform/gcp/control-plane/modules/virtual-machine/variables.tf
+++ b/terraform/gcp/control-plane/modules/virtual-machine/variables.tf
@@ -50,9 +50,9 @@ variable "compute" {
 variable "container" {
   description = "Container configuration for the control plane"
   type = object({
-    image   = string
-    command = optional(list(string))
-    env     = optional(list(string))
+    image       = string
+    command     = optional(list(string))
+    environment = optional(list(string))
   })
 }
 

--- a/terraform/gcp/control-plane/variables.tf
+++ b/terraform/gcp/control-plane/variables.tf
@@ -30,7 +30,7 @@ variable "network" {
     zone               = string
     network            = optional(string)
     subnetwork         = optional(string)
-    enable-external-ip = bool
+    enable-external-ip = optional(bool, true)
   })
 
   validation {
@@ -44,56 +44,36 @@ variable "network" {
     )
     error_message = "Either network or subnetwork must be specified in the network configuration."
   }
-  validation {
-    condition     = var.network.enable-external-ip != null
-    error_message = "Zone must not be empty."
-  }
 }
 
 variable "compute" {
   description = "Compute configuration for the VM"
   type = object({
-    boot-disk-image            = string
-    machine-type               = string
+    boot-disk-image            = optional(string, "projects/cos-cloud/global/images/cos-stable-113-18244-85-49")
+    machine-type               = optional(string, "e2-standard-2")
     min-cpu-platform           = optional(string)
     confidential-instance-type = optional(string)
-    shielded = object({
-      enable-secure-boot          = bool
-      enable-vtpm                 = bool
-      enable-integrity-monitoring = bool
-    })
-    confidential = object({
-      enable        = bool
-      instance-type = string
-    })
+    shielded = optional(object({
+      enable-secure-boot          = optional(bool, true)
+      enable-vtpm                 = optional(bool, true)
+      enable-integrity-monitoring = optional(bool, true)
+    }), {})
+    confidential = optional(object({
+      enable        = optional(bool, false)
+      instance-type = optional(string, "e2-standard-2")
+    }), {})
   })
-  default = {
-    machine-type    = "e2-standard-2"
-    boot-disk-image = "projects/cos-cloud/global/images/cos-stable-113-18244-85-49"
-    shielded = {
-      enable-secure-boot          = true
-      enable-vtpm                 = true
-      enable-integrity-monitoring = true
-    }
-    confidential = {
-      enable        = false
-      instance-type = "e2-standard-2"
-    }
-  }
+  default = {}
 }
 
 variable "container" {
   description = "Container configuration for the control plane"
   type = object({
-    image   = string
-    command = optional(list(string))
-    env     = optional(list(string))
+    image   = optional(string, "gatlingcorp/control-plane:latest")
+    command = optional(list(string), [])
+    environment     = optional(list(string), [])
   })
-  default = {
-    image   = "gatlingcorp/control-plane:latest"
-    command = []
-    env     = []
-  }
+  default = {}
 }
 
 variable "locations" {

--- a/terraform/gcp/location/variables.tf
+++ b/terraform/gcp/location/variables.tf
@@ -43,25 +43,24 @@ variable "instance-template" {
 variable "machine" {
   description = "Machine configuration for load testing infrastructure"
   type = object({
-    type        = string
-    preemptible = optional(bool)
-    engine      = string
-    image = object({
-      type    = string
-      java    = optional(string)
+    type        = optional(string, "c3-highcpu-4")
+    preemptible = optional(bool, false)
+    engine      = optional(string, "classic")
+    image = optional(object({
+      type    = optional(string, "certified")
+      java    = optional(string, "latest")
       project = optional(string)
       family  = optional(string)
       id      = optional(string)
-    })
-    disk = object({
-      sizeGb = number
-    })
+    }), {})
+    disk = optional(object({ sizeGb = number }), { sizeGb = 20 })
     network-interface = optional(object({
       network          = optional(string)
       subnetwork       = optional(string)
-      with-external-ip = optional(bool)
-    }))
+      with-external-ip = optional(bool, true)
+    }), {})
   })
+  default = {}
 
   validation {
     condition     = contains(["classic", "javascript"], var.machine.engine)

--- a/terraform/gcp/private-package/main.tf
+++ b/terraform/gcp/private-package/main.tf
@@ -1,9 +1,9 @@
 locals {
   private-package = {
     type    = "gcp"
+    project = var.project
     bucket  = var.bucket
     path    = var.path
-    project = var.project
     upload  = var.upload
     server  = var.server
   }

--- a/terraform/gcp/private-package/variables.tf
+++ b/terraform/gcp/private-package/variables.tf
@@ -37,18 +37,14 @@ variable "upload" {
 variable "server" {
   description = "Control Plane Repository Server configuration."
   type = object({
-    port        = number
-    bindAddress = string
+    port        = optional(number, 8080)
+    bindAddress = optional(string, "0.0.0.0")
     certificate = optional(object({
       path     = string
       password = optional(string)
-    }))
+    }), {})
   })
-  default = {
-    port        = 8080,
-    bindAddress = "0.0.0.0",
-    certificate = null
-  }
+  default = {}
 
   validation {
     condition     = var.server.port > 0 && var.server.port <= 65535

--- a/terraform/gcp/private-package/variables.tf
+++ b/terraform/gcp/private-package/variables.tf
@@ -40,7 +40,7 @@ variable "server" {
     port        = optional(number, 8080)
     bindAddress = optional(string, "0.0.0.0")
     certificate = optional(object({
-      path     = string
+      path     = optional(string)
       password = optional(string)
     }), {})
   })


### PR DESCRIPTION
Motivation:
Add granular defaults to input arg objects in order to improve the developer experience. No need to uncomment a whole input argument, but the parent and target child arg would suffice.

Modifications:
- Add defaults to the child values in a map input argument.