### PR TITLE
[Terraform Azure] feat: add granular defaults

### DIFF
--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -70,9 +70,9 @@ resource "azurerm_container_app" "gatling_container" {
       dynamic "env" {
         for_each = local.environment
         content {
-          name        = environment.value.name
-          value       = lookup(environment.value, "value", null)
-          secret_name = lookup(environment.value, "secret-name", null)
+          name        = env.value.name
+          value       = lookup(env.value, "value", null)
+          secret_name = lookup(env.value, "secret-name", null)
         }
       }
 

--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -2,14 +2,14 @@ locals {
   path        = "/app/conf"
   volume-name = "control-plane-conf"
   secret-name = "token-secret-id"
-  env = concat(
+  environment = concat(
     [
       {
         name        = "CONTROL_PLANE_TOKEN"
         secret-name = local.secret-name
       }
     ],
-    var.container.env
+    var.container.environment
   )
 }
 
@@ -68,11 +68,11 @@ resource "azurerm_container_app" "gatling_container" {
       command = var.container.command
 
       dynamic "env" {
-        for_each = local.env
+        for_each = local.environment
         content {
-          name        = env.value.name
-          value       = lookup(env.value, "value", null)
-          secret_name = lookup(env.value, "secret-name", null)
+          name        = environment.value.name
+          value       = lookup(environment.value, "value", null)
+          secret_name = lookup(environment.value, "secret-name", null)
         }
       }
 

--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_container_app" "gatling_container" {
   }
 
   dynamic "ingress" {
-    for_each = var.private-package == {} ? [] : [1]
+    for_each = length(var.private-package) > 0 ? [1] : []
     content {
       external_enabled = true
       target_port      = var.private-package.conf.server.port

--- a/terraform/azure/control-plane/modules/container-app/variables.tf
+++ b/terraform/azure/control-plane/modules/container-app/variables.tf
@@ -21,11 +21,11 @@ variable "resource-group-name" {
 variable "container" {
   description = "Container settings."
   type = object({
-    image   = string
-    command = optional(list(string))
-    env     = optional(list(map(string)))
-    cpu     = number
-    memory  = string
+    cpu         = number
+    memory      = string
+    image       = string
+    command     = optional(list(string))
+    environment = optional(list(map(string)))
   })
 }
 

--- a/terraform/azure/control-plane/modules/role-assignment/main.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_role_assignment" "gatling_custom_role_assignment" {
 }
 
 resource "azurerm_role_assignment" "gatling_storage_contributor" {
-  count                = var.private-package == {} ? 0 : 1
+  count                = length(var.private-package) > 0 ? 1 : 0
   scope                = data.azurerm_subscription.current.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = var.container.identity[0].principal_id

--- a/terraform/azure/control-plane/modules/role-assignment/main.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/main.tf
@@ -3,11 +3,9 @@ data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault_access_policy" "container_app_policy" {
-  key_vault_id = "${data.azurerm_subscription.current.id}/resourceGroups/${var.resource-group-name}/providers/Microsoft.KeyVault/vaults/${var.vault-name}"
-
-  tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = var.container.identity[0].principal_id
-
+  key_vault_id       = "${data.azurerm_subscription.current.id}/resourceGroups/${var.resource-group-name}/providers/Microsoft.KeyVault/vaults/${var.vault-name}"
+  tenant_id          = data.azurerm_client_config.current.tenant_id
+  object_id          = var.container.identity[0].principal_id
   secret_permissions = ["Get"]
 }
 

--- a/terraform/azure/control-plane/modules/storage-account/main.tf
+++ b/terraform/azure/control-plane/modules/storage-account/main.tf
@@ -21,7 +21,7 @@ resource "local_file" "json_file" {
       description = "${var.description}"
       enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
       locations = [ %{for location in var.locations} ${jsonencode(location.conf)}, %{endfor} ]
-      %{if var.private-package != {} }repository = ${jsonencode(var.private-package.conf)}%{endif}
+      %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
       %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
     }
   EOF

--- a/terraform/azure/control-plane/variables.tf
+++ b/terraform/azure/control-plane/variables.tf
@@ -57,6 +57,8 @@ variable "resource-group-name" {
 variable "container" {
   description = "Container settings."
   type = object({
+    cpu     = optional(number, 1.0)
+    memory  = optional(string, "2Gi")
     image   = optional(string, "gatlingcorp/control-plane:latest")
     command = optional(list(string), [])
     environment = optional(list(object({
@@ -64,8 +66,6 @@ variable "container" {
       value       = optional(string)
       secret-name = optional(string)
     })), [])
-    cpu    = optional(number, 1.0)
-    memory = optional(string, "2Gi")
   })
   default = {}
 }

--- a/terraform/azure/control-plane/variables.tf
+++ b/terraform/azure/control-plane/variables.tf
@@ -57,23 +57,17 @@ variable "resource-group-name" {
 variable "container" {
   description = "Container settings."
   type = object({
-    image   = string
-    command = optional(list(string))
-    env = optional(list(object({
-      name        = string
+    image   = optional(string, "gatlingcorp/control-plane:latest")
+    command = optional(list(string), [])
+    environment = optional(list(object({
+      name        = optional(string)
       value       = optional(string)
       secret-name = optional(string)
-    })))
-    cpu    = number
-    memory = string
+    })), [])
+    cpu    = optional(number, 1.0)
+    memory = optional(string, "2Gi")
   })
-  default = {
-    image  = "gatlingcorp/control-plane:latest"
-    cpu    = 1.0
-    memory = "2Gi"
-    command = []
-    env     = []
-  }
+  default = {}
 }
 
 variable "storage-account-name" {

--- a/terraform/azure/location/variables.tf
+++ b/terraform/azure/location/variables.tf
@@ -28,17 +28,25 @@ variable "engine" {
   description = "Engine of the location determining the compatible package formats (JavaScript or JVM)."
   type        = string
   default     = "classic"
+
+  validation {
+    condition     = contains(["classic", "javascript"], var.engine)
+    error_message = "The engine must be either 'classic' or 'javascript'."
+  }
 }
 
 variable "image" {
   description = "Image of the location."
   type = object({
-    type  = string
-    java  = optional(string)
+    type  = optional(string, "certified")
+    java  = optional(string, "latest")
     image = optional(string)
   })
-  default = {
-    type        = "certified"
+  default = {}
+
+  validation {
+    condition     = var.image.type != "custom" || var.image.image != null
+    error_message = "If image.type is 'custom', then image.image must be specified."
   }
 }
 
@@ -72,12 +80,6 @@ variable "subnet-name" {
   }
 }
 
-variable "java-version" {
-  description = "Java version of the location."
-  type        = string
-  default     = "latest"
-}
-
 variable "size" {
   description = "Virtual machine size of the location."
   type        = string
@@ -87,7 +89,7 @@ variable "size" {
 variable "associate-public-ip" {
   description = "Flag to enable public IP association."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "tags" {

--- a/terraform/azure/private-package/variables.tf
+++ b/terraform/azure/private-package/variables.tf
@@ -37,18 +37,14 @@ variable "upload" {
 variable "server" {
   description = "Control Plane Repository Server configuration."
   type = object({
-    port        = number
-    bindAddress = string
+    port        = optional(number, 8080)
+    bindAddress = optional(string, "0.0.0.0")
     certificate = optional(object({
-      path     = string
-      password = optional(string)
-    }))
+      path     = optional(string)
+      password = optional(string, null)
+    }), null)
   })
-  default = {
-    port        = 8080,
-    bindAddress = "0.0.0.0",
-    certificate = null
-  }
+  default = {}
 
   validation {
     condition     = var.server.port > 0 && var.server.port <= 65535

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -45,7 +45,7 @@ module "location" {
   # }
   # size                = "Standard_A4_v2"
   # engine              = "classic"
-  # associate-public-ip = false
+  # associate-public-ip = true
   # tags                = {}
   # system_properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
@@ -74,11 +74,11 @@ module "control-plane" {
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   cpu     = 1.0
-  #   memory  = "2Gi"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   cpu         = 1.0
+  #   memory      = "2Gi"
+  #   command     = []
+  #   environment = []
   # }
   # enterprise_cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -34,7 +34,8 @@ This module specifies the location parameters for the control plane, including r
 module "location" {
   source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
   id           = "prl_azure"
-  region       = "<Region>"
+  description  = "Private Location on Azure"
+  region       = "westeurope"
   subscription = "<SubscriptionUUID>"
   network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
   subnet-name  = "<Subnet>"
@@ -67,20 +68,20 @@ Sets up the control plane with configurations for networking, security, and stor
 module "control-plane" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "<Name>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
   vault-name           = "<Vault>"
   secret-id            = "<SecretIdentifier>"
+  region               = "<Region>"
+  resource-group-name  = "<ResourceGroup>"
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   # container = {
-  #   image       = "gatlingcorp/control-plane:latest"
   #   cpu         = 1.0
   #   memory      = "2Gi"
+  #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
   # }
-  # enterprise_cloud = {
+  # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -7,7 +7,8 @@ provider "azurerm" {
 module "location" {
   source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
   id           = "prl_azure"
-  region       = "<Region>"
+  description  = "Private Location on Azure"
+  region       = "westeurope"
   subscription = "<SubscriptionUUID>"
   network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
   subnet-name  = "<Subnet>"
@@ -34,20 +35,20 @@ module "location" {
 module "control-plane" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "<Name>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
   vault-name           = "<Vault>"
   secret-id            = "<SecretIdentifier>"
+  region               = "<Region>"
+  resource-group-name  = "<ResourceGroup>"
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   # container = {
-  #   image       = "gatlingcorp/control-plane:latest"
   #   cpu         = 1.0
   #   memory      = "2Gi"
+  #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
   # }
-  # enterprise_cloud = {
+  # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -18,7 +18,7 @@ module "location" {
   # }
   # size                = "Standard_A4_v2"
   # engine              = "classic"
-  # associate-public-ip = false
+  # associate-public-ip = true
   # tags                = {}
   # system_properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
@@ -41,11 +41,11 @@ module "control-plane" {
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   cpu     = 1.0
-  #   memory  = "2Gi"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   cpu         = 1.0
+  #   memory      = "2Gi"
+  #   command     = []
+  #   environment = []
   # }
   # enterprise_cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -35,6 +35,18 @@ module "private-package" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/private-package"
   control-plane-name   = "<Name>"
   storage-account-name = "<StorageAccountName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 ```
 
@@ -48,7 +60,8 @@ This module specifies the location parameters for the control plane, including r
 module "location" {
   source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
   id           = "prl_azure"
-  region       = "<Region>"
+  description  = "Private Location on Azure"
+  region       = "westeurope"
   subscription = "<SubscriptionUUID>"
   network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
   subnet-name  = "<Subnet>"
@@ -81,21 +94,21 @@ Sets up the control plane with configurations for networking, security, and stor
 module "control-plane" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "<Name>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
   vault-name           = "<Vault>"
   secret-id            = "<SecretIdentifier>"
+  region               = "<Region>"
+  resource-group-name  = "<ResourceGroup>"
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   private-package      = module.private-package
   # container = {
-  #   image       = "gatlingcorp/control-plane:latest"
   #   cpu         = 1.0
   #   memory      = "2Gi"
+  #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
   # }
-  # enterprise_cloud = {
+  # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -59,7 +59,7 @@ module "location" {
   # }
   # size                = "Standard_A4_v2"
   # engine              = "classic"
-  # associate-public-ip = false
+  # associate-public-ip = true
   # tags                = {}
   # system_properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
@@ -89,11 +89,11 @@ module "control-plane" {
   locations            = [module.location]
   private-package      = module.private-package
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   cpu     = 1.0
-  #   memory  = "2Gi"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   cpu         = 1.0
+  #   memory      = "2Gi"
+  #   command     = []
+  #   environment = []
   # }
   # enterprise_cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -27,7 +27,7 @@ module "location" {
   # }
   # size                = "Standard_A4_v2"
   # engine              = "classic"
-  # associate-public-ip = false
+  # associate-public-ip = true
   # tags                = {}
   # system_properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
@@ -51,11 +51,11 @@ module "control-plane" {
   locations            = [module.location]
   private-package      = module.private-package
   # container = {
-  #   image   = "gatlingcorp/control-plane:latest"
-  #   cpu     = 1.0
-  #   memory  = "2Gi"
-  #   command = []
-  #   env     = []
+  #   image       = "gatlingcorp/control-plane:latest"
+  #   cpu         = 1.0
+  #   memory      = "2Gi"
+  #   command     = []
+  #   environment = []
   # }
   # enterprise_cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -9,6 +9,18 @@ module "private-package" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/private-package"
   control-plane-name   = "<Name>"
   storage-account-name = "<StorageAccountName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 
 # Configure a Azure private location
@@ -16,12 +28,13 @@ module "private-package" {
 module "location" {
   source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
   id           = "prl_azure"
-  region       = "<Region>"
+  description  = "Private Location on Azure"
+  region       = "westeurope"
   subscription = "<SubscriptionUUID>"
   network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
   subnet-name  = "<Subnet>"
   # image = {
-  #   type = "certified"
+  #   type  = "certified"
   #   java  = "latest"
   #   image = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Compute/galleries/customImages/images/<Image>"
   # }
@@ -43,21 +56,21 @@ module "location" {
 module "control-plane" {
   source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
   name                 = "<Name>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
   vault-name           = "<Vault>"
   secret-id            = "<SecretIdentifier>"
+  region               = "<Region>"
+  resource-group-name  = "<ResourceGroup>"
   storage-account-name = "<StorageAccount>"
   locations            = [module.location]
   private-package      = module.private-package
   # container = {
-  #   image       = "gatlingcorp/control-plane:latest"
   #   cpu         = 1.0
   #   memory      = "2Gi"
+  #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
   # }
-  # enterprise_cloud = {
+  # enterprise-cloud = {
   #   Setup the proxy configuration for the private location
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }


### PR DESCRIPTION
Motivation:
Add granular defaults to input arg objects in order to improve the developer experience. No need to uncomment a whole input argument, but the parent and target child arg would suffice.

Modifications:
Add defaults to the child values in a map input argument.