### PR TITLE
[Terraform AWS] feat: add granular defaults for input args

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -20,10 +20,7 @@ module "ecs" {
   security-groups  = var.security-groups
   assign-public-ip = var.assign-public-ip
   token-secret-arn = var.token-secret-arn
-  task = merge(
-    var.task,
-    { iam-role-arn = module.iam.task-role-arn }
-  )
+  task             = merge(var.task, { iam-role-arn = module.iam.task-role-arn })
   locations        = var.locations
   private-package  = var.private-package
   enterprise-cloud = var.enterprise-cloud

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -10,7 +10,7 @@ locals {
       token = $${?CONTROL_PLANE_TOKEN}
       description = "${var.description}"
       enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
-      locations = [ %{for location in var.locations} ${jsonencode(location.conf)}, %{endfor} ]
+      locations = [%{for location in var.locations} ${jsonencode(location.conf)}, %{endfor}]
       %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
       %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
     }

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -67,7 +67,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
       command : var.task.command
       cpu : 0
       essential : true
-      portMappings : length(var.private-package) > 0  ? [
+      portMappings : length(var.private-package) > 0 ? [
         {
           containerPort : var.private-package.conf.server.port,
           hostPort : var.private-package.conf.server.port,

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -69,8 +69,8 @@ variable "private-package" {
 
 variable "enterprise-cloud" {
   description = "Enterprise Cloud network settings: http proxy, fwd proxy, etc."
-  type    = map(any)
-  default = {}
+  type        = map(any)
+  default     = {}
 }
 
 variable "extra-content" {

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -17,15 +17,25 @@ variable "token-secret-arn" {
 variable "subnets" {
   description = "The subnet IDs for the control plane."
   type        = list(string)
+
+  validation {
+    condition     = length(var.subnets) > 0
+    error_message = "Subnets must not be empty."
+  }
 }
 
 variable "security-groups" {
   description = "Security group IDs to be used with the control plane."
   type        = list(string)
+
+  validation {
+    condition     = length(var.security-groups) > 0
+    error_message = "Security groups must not be empty."
+  }
 }
 
 variable "assign-public-ip" {
-  description = "Assign public IP o th control plane service."
+  description = "Assign public IP to the control plane service."
   type        = bool
   default     = true
 }
@@ -33,27 +43,17 @@ variable "assign-public-ip" {
 variable "task" {
   description = "Conrol plane task definition."
   type = object({
-    iam-role-arn    = optional(string)
-    image           = string
-    command         = optional(list(string))
-    secrets         = optional(list(map(string)))
-    environment     = optional(list(map(string)))
-    cpu             = optional(string)
-    memory          = optional(string)
-    cloudwatch-logs = optional(bool)
-    ecr             = optional(bool)
+    iam-role-arn    = optional(string, "")
+    cpu             = optional(string, "1024")
+    memory          = optional(string, "3072")
+    image           = optional(string, "gatlingcorp/control-plane:latest")
+    command         = optional(list(string), [])
+    secrets         = optional(list(map(string)), [])
+    environment     = optional(list(map(string)), [])
+    cloudwatch-logs = optional(bool, true)
+    ecr             = optional(bool, false)
   })
-  default = {
-    iam-role-arn    = ""
-    image           = "gatlingcorp/control-plane:latest"
-    command         = []
-    secrets         = []
-    environment     = []
-    cpu             = "1024"
-    memory          = "3072"
-    cloudwatch-logs = true
-    ecr             = false
-  }
+  default = {}
 }
 
 variable "locations" {

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -94,7 +94,7 @@ variable "elastic-ips" {
   default     = []
 
   validation {
-    condition     = !(var.auto-associate-public-ipv4 && length(var.elastic_ips) > 0)
+    condition     = !(var.auto-associate-public-ipv4 && length(var.elastic-ips) > 0)
     error_message = "When elastic_ips are provided, auto-associate-public-ipv4 must be false."
   }
 }

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -28,6 +28,11 @@ variable "engine" {
   description = "Engine of the location determining the compatible package formats (JavaScript or JVM)."
   type        = string
   default     = "classic"
+
+  validation {
+    condition     = contains(["classic", "javascript"], var.engine)
+    error_message = "The engine must be either 'classic' or 'javascript'."
+  }
 }
 
 variable "instance-type" {
@@ -45,12 +50,15 @@ variable "spot" {
 variable "ami" {
   description = "Image of the location."
   type = object({
-    type = string
-    java = optional(string)
+    type = optional(string, "certified")
+    java = optional(string, "latest")
     id   = optional(string)
   })
-  default = {
-    type = "certified"
+  default = {}
+
+  validation {
+    condition     = var.ami.type != "custom" || var.ami.id != null
+    error_message = "If ami.type is 'custom', then ami.id must be specified."
   }
 }
 
@@ -84,6 +92,11 @@ variable "elastic-ips" {
   description = "Assign elastic IPs to your Locations. You will only be able to deploy a number of load generators up to the number of Elastic IP addresses you have configured."
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = !(var.auto_associate_public_ipv4 && length(var.elastic_ips) > 0)
+    error_message = "When elastic_ips are provided, auto-associate-public-ipv4 must be false."
+  }
 }
 
 variable "profile-name" {
@@ -107,15 +120,11 @@ variable "tags" {
 variable "tags-for" {
   description = "Tags to be assigned to the resources of the Location."
   type = object({
-    instance          = map(string)
-    volume            = map(string)
-    network-interface = map(string)
+    instance          = optional(map(string), {})
+    volume            = optional(map(string), {})
+    network-interface = optional(map(string), {})
   })
-  default = {
-    instance : {}
-    volume : {}
-    network-interface : {}
-  }
+  default = {}
 }
 
 variable "system-properties" {

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -92,6 +92,11 @@ variable "elastic-ips" {
   description = "Assign elastic IPs to your Locations. You will only be able to deploy a number of load generators up to the number of Elastic IP addresses you have configured."
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = !(var.auto-associate-public-ipv4 && length(var.elastic-ips) > 0)
+    error_message = "When elastic_ips are provided, auto-associate-public-ipv4 must be false."
+  }
 }
 
 variable "profile-name" {

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -94,7 +94,7 @@ variable "elastic-ips" {
   default     = []
 
   validation {
-    condition     = !(var.auto_associate_public_ipv4 && length(var.elastic_ips) > 0)
+    condition     = !(var.auto-associate-public-ipv4 && length(var.elastic_ips) > 0)
     error_message = "When elastic_ips are provided, auto-associate-public-ipv4 must be false."
   }
 }

--- a/terraform/aws/location/variables.tf
+++ b/terraform/aws/location/variables.tf
@@ -92,11 +92,6 @@ variable "elastic-ips" {
   description = "Assign elastic IPs to your Locations. You will only be able to deploy a number of load generators up to the number of Elastic IP addresses you have configured."
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = !(var.auto-associate-public-ipv4 && length(var.elastic-ips) > 0)
-    error_message = "When elastic_ips are provided, auto-associate-public-ipv4 must be false."
-  }
 }
 
 variable "profile-name" {

--- a/terraform/aws/private-package/variables.tf
+++ b/terraform/aws/private-package/variables.tf
@@ -27,18 +27,14 @@ variable "upload" {
 variable "server" {
   description = "Control Plane Repository Server configuration."
   type = object({
-    port        = number
-    bindAddress = string
+    port        = optional(number, 8080)
+    bindAddress = optional(string, "0.0.0.0")
     certificate = optional(object({
-      path     = string
-      password = optional(string)
-    }))
+      path     = optional(string)
+      password = optional(string, null)
+    }), null)
   })
-  default = {
-    port        = 8080,
-    bindAddress = "0.0.0.0",
-    certificate = null
-  }
+  default = {}
 
   validation {
     condition     = var.server.port > 0 && var.server.port <= 65535

--- a/terraform/examples/AWS-private-location/README.md
+++ b/terraform/examples/AWS-private-location/README.md
@@ -34,6 +34,7 @@ Ensure that your network permits outbound access to the domains listed in this d
 module "location" {
   source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
   id              = "prl_aws"
+  description     = "Private Location on AWS"
   region          = "<Region>"
   subnets         = ["<SubnetId>"]
   security-groups = ["<SecurityGroupId>"]
@@ -75,17 +76,18 @@ Sets up the control plane with configurations for networking, security, and S3 s
 module "control-plane" {
   source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
   name             = "<Name>"
+  description      = "My AWS control plane description"
   token-secret-arn = "<TokenSecretARN>"
   subnets          = ["<SubnetId>"]
   security-groups  = ["<SecurityGroupId>"]
   locations        = [module.location]
   # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []
   #   environment     = []
-  #   cpu             = "1024"
-  #   memory          = "3072"
   #   cloudwatch-logs = true
   #   ecr             = false
   # }

--- a/terraform/examples/AWS-private-location/main.tf
+++ b/terraform/examples/AWS-private-location/main.tf
@@ -7,6 +7,7 @@ provider "aws" {
 module "location" {
   source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
   id              = "prl_aws"
+  description     = "Private Location on AWS"
   region          = "<Region>"
   subnets         = ["<SubnetId>"]
   security-groups = ["<SecurityGroupId>"]
@@ -42,17 +43,18 @@ module "location" {
 module "control-plane" {
   source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
   name             = "<Name>"
+  description      = "My AWS control plane description"
   token-secret-arn = "<TokenSecretARN>"
   subnets          = ["<SubnetId>"]
   security-groups  = ["<SecurityGroupId>"]
   locations        = [module.location]
   # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []
   #   environment     = []
-  #   cpu             = "1024"
-  #   memory          = "3072"
   #   cloudwatch-logs = true
   #   ecr             = false
   # }

--- a/terraform/examples/AWS-private-package/README.md
+++ b/terraform/examples/AWS-private-package/README.md
@@ -48,6 +48,7 @@ Ensure that your network permits outbound access to the domains listed in this d
 module "location" {
   source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
   id              = "prl_aws"
+  description     = "Private Location on AWS"
   region          = "<Region>"
   subnets         = ["<SubnetId>"]
   security-groups = ["<SecurityGroupId>"]
@@ -89,18 +90,19 @@ Sets up the control plane with configurations for networking, security, and S3 s
 module "control-plane" {
   source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
   name             = "<Name>"
+  description      = "My AWS control plane description"
   token-secret-arn = "<TokenSecretARN>"
   subnets          = ["<SubnetId>"]
   security-groups  = ["<SecurityGroupId>"]
   locations        = [module.location]
   private-package  = module.private-package
   # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []
   #   environment     = []
-  #   cpu             = "1024"
-  #   memory          = "3072"
   #   cloudwatch-logs = true
   #   ecr             = false
   # }

--- a/terraform/examples/AWS-private-package/README.md
+++ b/terraform/examples/AWS-private-package/README.md
@@ -34,6 +34,18 @@ This module specifies the private package parameters for the control plane. It i
 module "private-package" {
   source = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/private-package"
   bucket = "<S3BucketName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 ```
 

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -15,6 +15,7 @@ module "private-package" {
 module "location" {
   source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
   id              = "prl_aws"
+  description     = "Private Location on AWS"
   region          = "<Region>"
   subnets         = ["<SubnetId>"]
   security-groups = ["<SecurityGroupId>"]
@@ -50,18 +51,19 @@ module "location" {
 module "control-plane" {
   source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
   name             = "<Name>"
+  description      = "My AWS control plane description"
   token-secret-arn = "<TokenSecretARN>"
   subnets          = ["<SubnetId>"]
   security-groups  = ["<SecurityGroupId>"]
   locations        = [module.location]
   private-package  = module.private-package
   # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []
   #   environment     = []
-  #   cpu             = "1024"
-  #   memory          = "3072"
   #   cloudwatch-logs = true
   #   ecr             = false
   # }

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "<Region>"
+  region = "eu-west-3"
 }
 
 # Configure a private package (control plane repository & server) based on AWS S3
@@ -8,6 +8,18 @@ provider "aws" {
 module "private-package" {
   source = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/private-package"
   bucket = "<S3BucketName>"
+  # path    = ""
+  # upload = {
+  #   directory = "/tmp"
+  # }
+  # server = {
+  #   port        = 8080
+  #   bindAddress = "0.0.0.0"
+  #   certificate = {
+  #     path     = "/path/to/certificate.p12"
+  #     password = "password"
+  #   }
+  # }
 }
 
 # Configure a AWS private location

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -32,28 +32,36 @@ This module specifies the location parameters for the control plane, including r
 # Configure a Azure private location
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/configuration/#control-plane-configuration-file
 module "location" {
-  source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
-  id           = "prl_azure"
-  description  = "Private Location on Azure"
-  region       = "westeurope"
-  subscription = "<SubscriptionUUID>"
-  network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
-  subnet-name  = "<Subnet>"
-  # image = {
-  #   type  = "certified"
-  #   java  = "latest"
-  #   image = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Compute/galleries/customImages/images/<Image>"
+  source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
+  id              = "prl_aws"
+  description     = "Private Location on AWS"
+  region          = "<Region>"
+  subnets         = ["<SubnetId>"]
+  security-groups = ["<SecurityGroupId>"]
+  # instance-type   = "c7i.xlarge"
+  # engine          = "classic"
+  # ami = {
+  #   type = "certified"
+  #   java = "latest"
+  #   id   = "ami-00000000000000000"
   # }
-  # size                = "Standard_A4_v2"
-  # engine              = "classic"
-  # associate-public-ip = true
-  # tags                = {}
-  # system_properties   = {}
+  # spot                       = false
+  # auto-associate-public-ipv4 = true
+  # elastic-ips                = ["203.0.113.3", "203.0.113.4"]
+  # profile-name               = "profile-name"
+  # iam-instance-profile = "iam-instance-profile"
+  # tags                       = {}
+  # tags-for = {
+  #   instance          = {}
+  #   volume            = {}
+  #   network-interface = {}
+  # }
+  # system-properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
   # jvm-options         = []
   # enterprise-cloud = {
-  #   #  Setup the proxy configuration for the private location
-  #   #  Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
+  #   Setup the proxy configuration for the private location
+  #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }
 }
 ```
@@ -66,23 +74,25 @@ Sets up the control plane with configurations for networking, security, and stor
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  # container = {
-  #   cpu         = 1.0
-  #   memory      = "2Gi"
-  #   image       = "gatlingcorp/control-plane:latest"
-  #   command     = []
-  #   environment = []
+  source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
+  name             = "<Name>"
+  description      = "My AWS control plane description"
+  token-secret-arn = "<TokenSecretARN>"
+  subnets          = ["<SubnetId>"]
+  security-groups  = ["<SecurityGroupId>"]
+  locations        = [module.location]
+  # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
+  #   image           = "gatlingcorp/control-plane:latest"
+  #   command         = []
+  #   secrets         = []
+  #   environment     = []
+  #   cloudwatch-logs = true
+  #   ecr             = false
   # }
   # enterprise-cloud = {
-  #   Setup the proxy configuration for the private location
+  #   Setup the proxy configuration for the control plane
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }
 }

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -5,51 +5,61 @@ provider "azurerm" {
 # Configure a Azure private location
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/configuration/#control-plane-configuration-file
 module "location" {
-  source       = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/location"
-  id           = "prl_azure"
-  description  = "Private Location on Azure"
-  region       = "westeurope"
-  subscription = "<SubscriptionUUID>"
-  network-id   = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/virtualNetworks/<VNet>"
-  subnet-name  = "<Subnet>"
-  # image = {
-  #   type  = "certified"
-  #   java  = "latest"
-  #   image = "/subscriptions/<SubscriptionUUID>/resourceGroups/<ResourceGroup>/providers/Microsoft.Compute/galleries/customImages/images/<Image>"
+  source          = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/location"
+  id              = "prl_aws"
+  description     = "Private Location on AWS"
+  region          = "<Region>"
+  subnets         = ["<SubnetId>"]
+  security-groups = ["<SecurityGroupId>"]
+  # instance-type   = "c7i.xlarge"
+  # engine          = "classic"
+  # ami = {
+  #   type = "certified"
+  #   java = "latest"
+  #   id   = "ami-00000000000000000"
   # }
-  # size                = "Standard_A4_v2"
-  # engine              = "classic"
-  # associate-public-ip = true
-  # tags                = {}
-  # system_properties   = {}
+  # spot                       = false
+  # auto-associate-public-ipv4 = true
+  # elastic-ips                = ["203.0.113.3", "203.0.113.4"]
+  # profile-name               = "profile-name"
+  # iam-instance-profile = "iam-instance-profile"
+  # tags                       = {}
+  # tags-for = {
+  #   instance          = {}
+  #   volume            = {}
+  #   network-interface = {}
+  # }
+  # system-properties   = {}
   # java-home           = "/usr/lib/jvm/zulu"
   # jvm-options         = []
   # enterprise-cloud = {
-  #   #  Setup the proxy configuration for the private location
-  #   #  Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
+  #   Setup the proxy configuration for the private location
+  #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }
 }
 
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  # container = {
-  #   cpu         = 1.0
-  #   memory      = "2Gi"
-  #   image       = "gatlingcorp/control-plane:latest"
-  #   command     = []
-  #   environment = []
+  source           = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/aws/control-plane"
+  name             = "<Name>"
+  description      = "My AWS control plane description"
+  token-secret-arn = "<TokenSecretARN>"
+  subnets          = ["<SubnetId>"]
+  security-groups  = ["<SecurityGroupId>"]
+  locations        = [module.location]
+  # task = {
+  #   cpu             = "1024"
+  #   memory          = "3072"
+  #   image           = "gatlingcorp/control-plane:latest"
+  #   command         = []
+  #   secrets         = []
+  #   environment     = []
+  #   cloudwatch-logs = true
+  #   ecr             = false
   # }
   # enterprise-cloud = {
-  #   Setup the proxy configuration for the private location
+  #   Setup the proxy configuration for the control plane
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy
   # }
 }


### PR DESCRIPTION
Motivation:
Add granular defaults to input arg objects in order to improve the developer experience. No need to uncomment a whole input argument, but the parent and target child arg would suffice.

Modifications:
Add defaults to the child values in a map input argument.