### PR TITLE
[TF-AWS] Feat: custom init container image support

### DIFF
--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_task_definition" "gatling_task" {
   container_definitions = jsonencode([
     {
       name : "conf-loader-init-container"
-      image : "busybox"
+      image : var.task.init.image
       cpu : 0
       essential : false
       command : [

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -35,13 +35,16 @@ variable "assign-public-ip" {
 variable "task" {
   description = "Conrol plane task definition."
   type = object({
-    iam-role-arn    = string
+    iam-role-arn = string
+    init = object({
+      image = string
+    })
     image           = string
-    command         = optional(list(string))
-    secrets         = optional(list(map(string)))
-    environment     = optional(list(map(string)))
-    cpu             = optional(string)
-    memory          = optional(string)
+    command         = list(string)
+    secrets         = list(map(string))
+    environment     = list(map(string))
+    cpu             = string
+    memory          = string
     cloudwatch-logs = bool
     ecr             = bool
   })

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -43,10 +43,13 @@ variable "assign-public-ip" {
 variable "task" {
   description = "Conrol plane task definition."
   type = object({
-    iam-role-arn    = optional(string, "")
-    cpu             = optional(string, "1024")
-    memory          = optional(string, "3072")
-    image           = optional(string, "gatlingcorp/control-plane:latest")
+    iam-role-arn = optional(string, "")
+    cpu          = optional(string, "1024")
+    memory       = optional(string, "3072")
+    image        = optional(string, "gatlingcorp/control-plane:latest")
+    init = optional(object({
+      image = optional(string, "busybox")
+    }), {})
     command         = optional(list(string), [])
     secrets         = optional(list(map(string)), [])
     environment     = optional(list(map(string)), [])

--- a/terraform/examples/AWS-private-location/README.md
+++ b/terraform/examples/AWS-private-location/README.md
@@ -93,6 +93,9 @@ module "control-plane" {
   # task = {
   #   cpu             = "1024"
   #   memory          = "3072"
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []

--- a/terraform/examples/AWS-private-location/main.tf
+++ b/terraform/examples/AWS-private-location/main.tf
@@ -51,6 +51,9 @@ module "control-plane" {
   # task = {
   #   cpu             = "1024"
   #   memory          = "3072"
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []

--- a/terraform/examples/AWS-private-package/README.md
+++ b/terraform/examples/AWS-private-package/README.md
@@ -118,8 +118,11 @@ module "control-plane" {
   locations        = [module.location]
   private-package  = module.private-package
   # task = {
-  #   cpu             = "1024"
-  #   memory          = "3072"
+  #   cpu    = "1024"
+  #   memory = "3072"
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -72,6 +72,9 @@ module "control-plane" {
   # task = {
   #   cpu             = "1024"
   #   memory          = "3072"
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   image           = "gatlingcorp/control-plane:latest"
   #   command         = []
   #   secrets         = []


### PR DESCRIPTION
Motivation:
Enterprises requiring private images will need to configure a custom init container image.

Modification:
Add `task.init.image` to the control plane module, with a default value of `busybox`.