### PR TITLE
[TF-AWS] Build from sources support

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -7,6 +7,7 @@ module "iam" {
   token-secret-arn = var.token-secret-arn
   locations        = var.locations
   private-package  = var.private-package
+  git              = var.git
   cloudwatch-logs  = var.task.cloudwatch-logs
   ecr              = var.task.ecr
 }
@@ -21,6 +22,7 @@ module "ecs" {
   assign-public-ip = var.assign-public-ip
   token-secret-arn = var.token-secret-arn
   task             = merge(var.task, { iam-role-arn = module.iam.task-role-arn })
+  git              = var.git
   locations        = var.locations
   private-package  = var.private-package
   enterprise-cloud = var.enterprise-cloud

--- a/terraform/aws/control-plane/modules/ecs/main.tf
+++ b/terraform/aws/control-plane/modules/ecs/main.tf
@@ -1,10 +1,8 @@
-resource "aws_ecs_cluster" "gatling_cluster" {
-  name = "${var.name}-cluster"
-}
-
 locals {
-  path           = "/app/conf"
-  volume_name    = "control-plane-conf"
+  conf_path      = "/app/conf"
+  ssh_path       = "/app/.ssh"
+  git_path       = "${local.conf_path}/.git-credentials"
+  volume_name    = "control-plane-volume"
   config_content = <<-EOF
     control-plane {
       token = $${?CONTROL_PLANE_TOKEN}
@@ -22,6 +20,95 @@ locals {
   }
   token_secret = { name = "CONTROL_PLANE_TOKEN", valueFrom = var.token-secret-arn }
   ecs_secrets  = concat(var.task.secrets, [local.token_secret])
+  git = {
+    ssh_enabled   = length(var.git.ssh.private-key-secret-arn) > 0
+    creds_enabled = length(var.git.credentials.username) > 0 && length(var.git.credentials.token-secret-arn) > 0
+  }
+  mountPoints = concat(
+    [
+      {
+        sourceVolume : local.volume_name
+        containerPath : local.conf_path
+        readOnly : true
+      }
+    ],
+    local.git.ssh_enabled ? [
+      {
+        sourceVolume : local.volume_name
+        containerPath : local.ssh_path
+        readOnly : true
+      }
+    ] : [],
+    [
+      for cache_path in var.git.cache.paths : {
+        sourceVolume  = local.volume_name
+        containerPath = cache_path
+        readOnly      = false
+      }
+  ])
+  init_commands = compact([
+    "echo \"$CONFIG_CONTENT\" > ${local.conf_path}/control-plane.conf && chown -R 1001 ${local.conf_path} && chmod 400 ${local.conf_path}/control-plane.conf",
+    local.git.ssh_enabled ? "echo 'Host ${var.git.host}\n IdentityFile ${local.ssh_path}/id_gatling\n  StrictHostKeyChecking no' >> ${local.ssh_path}/config && echo \"$SSH_KEY\" > ${local.ssh_path}/id_gatling && chown -R 1001 ${local.ssh_path} && chmod 400 ${local.ssh_path}/id_gatling" : "",
+    local.git.creds_enabled ? "echo \"https://$GIT_USERNAME:$GIT_TOKEN@${var.git.host}\" > ${local.git_path} && chown -R 1001 ${local.conf_path} && chmod 400 ${local.git_path}" : "",
+  ])
+  init = {
+    command = [
+      "/bin/sh",
+      "-c",
+      join(" && ", local.init_commands)
+    ]
+    secrets = concat(
+      local.git.creds_enabled ? [
+        {
+          name      = "GIT_TOKEN"
+          valueFrom = var.git.credentials.token-secret-arn
+        }
+      ] : [],
+      local.git.ssh_enabled ? [
+        {
+          name      = "SSH_KEY"
+          valueFrom = var.git.ssh.private-key-secret-arn
+        }
+      ] : []
+    )
+    environment = concat(
+      [
+        {
+          name  = "CONFIG_CONTENT"
+          value = local.config_content
+        }
+      ],
+      local.git.creds_enabled ? [
+        {
+          name  = "GIT_USERNAME"
+          value = var.git.credentials.username
+        },
+        {
+          name  = "GIT_CREDENTIALS"
+          value = local.git_path
+        }
+      ] : []
+    )
+    mountPoints = concat(
+      [
+        {
+          sourceVolume : local.volume_name
+          containerPath : local.conf_path
+          readOnly : false
+        }
+      ],
+      local.git.ssh_enabled ? [
+        {
+          sourceVolume : local.volume_name
+          containerPath : local.ssh_path
+          readOnly : false
+        }
+    ] : [])
+  }
+}
+
+resource "aws_ecs_cluster" "gatling_cluster" {
+  name = "${var.name}-cluster"
 }
 
 resource "aws_ecs_task_definition" "gatling_task" {
@@ -38,24 +125,10 @@ resource "aws_ecs_task_definition" "gatling_task" {
       image : var.task.init.image
       cpu : 0
       essential : false
-      command : [
-        "/bin/sh",
-        "-c",
-        "echo \"$CONFIG_CONTENT\" > ${local.path}/control-plane.conf"
-      ]
-      environment : [
-        {
-          name : "CONFIG_CONTENT",
-          value : local.config_content
-        }
-      ]
-      mountPoints : [
-        {
-          sourceVolume : local.volume_name
-          containerPath : local.path
-          readOnly : false
-        }
-      ]
+      command : local.init.command
+      environment : local.init.environment
+      secrets : local.init.secrets
+      mountPoints : local.init.mountPoints
       logConfiguration : var.task.cloudwatch-logs ? {
         logDriver : "awslogs"
         options : merge(local.log_group, { "awslogs-stream-prefix" : "init" })
@@ -74,16 +147,13 @@ resource "aws_ecs_task_definition" "gatling_task" {
           protocol : "tcp"
         }
       ] : []
-      workingDirectory : local.path
+      workingDirectory : local.conf_path
       secrets : local.ecs_secrets
-      environment : var.task.environment
-      mountPoints : [
-        {
-          sourceVolume : local.volume_name
-          containerPath : local.path
-          readOnly : true
-        }
-      ]
+      environment : concat(var.task.environment, local.git.creds_enabled ? [{
+        name  = "GIT_CREDENTIALS"
+        value = local.git_path
+      }] : [])
+      mountPoints : local.mountPoints
       logConfiguration : var.task.cloudwatch-logs ? {
         logDriver : "awslogs"
         options : merge(local.log_group, { "awslogs-stream-prefix" : "main" })

--- a/terraform/aws/control-plane/modules/ecs/variables.tf
+++ b/terraform/aws/control-plane/modules/ecs/variables.tf
@@ -50,6 +50,23 @@ variable "task" {
   })
 }
 
+variable "git" {
+  description = "Conrol plane git configuration."
+  type = object({
+    host = string
+    credentials = object({
+      username            = string
+      token-secret-arn = string
+    })
+    ssh = object({
+      private-key-secret-arn = string
+    }),
+    cache = object({
+      paths   = list(string)
+    })
+  })
+}
+
 variable "locations" {
   description = "JSON configuration for the locations."
   type        = list(any)

--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -102,6 +102,11 @@ locals {
     local.elastic_ip_statements,
     local.iam_profile_name_statements
   )
+
+  git = {
+    ssh_enabled   = length(var.git.ssh.private-key-secret-arn) > 0
+    creds_enabled = length(var.git.credentials.username) > 0 && length(var.git.credentials.token-secret-arn) > 0
+  }
 }
 
 resource "aws_iam_role" "gatling_role" {
@@ -157,7 +162,7 @@ resource "aws_iam_policy" "asm_policy" {
         Action = [
           "secretsmanager:GetSecretValue"
         ],
-        Resource = var.token-secret-arn
+        Resource = concat([var.token-secret-arn], local.git.creds_enabled ? [var.git.credentials.token-secret-arn] : [], local.git.ssh_enabled ? [var.git.ssh.private-key-secret-arn] : [])
       }
     ]
   })

--- a/terraform/aws/control-plane/modules/iam/variables.tf
+++ b/terraform/aws/control-plane/modules/iam/variables.tf
@@ -4,7 +4,7 @@ variable "token-secret-arn" {
 }
 
 variable "aws_region" {
-  type        = string
+  type = string
 }
 
 variable "name" {
@@ -20,6 +20,23 @@ variable "locations" {
 variable "private-package" {
   description = "JSON configuration for the private packages."
   type        = map(any)
+}
+
+variable "git" {
+  description = "Conrol plane git configuration."
+  type = object({
+    host = string
+    credentials = object({
+      username            = string
+      token-secret-arn = string
+    })
+    ssh = object({
+      private-key-secret-arn = string
+    }),
+    cache = object({
+      paths   = list(string)
+    })
+  })
 }
 
 variable "cloudwatch-logs" {

--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -40,6 +40,32 @@ variable "assign-public-ip" {
   default     = true
 }
 
+variable "git" {
+  description = "Conrol plane git configuration."
+  type = object({
+    host = optional(string, "")
+    credentials = optional(object({
+      username            = optional(string, "")
+      token-secret-arn = optional(string, "")
+    }), {})
+    ssh = optional(object({
+      private-key-secret-arn = optional(string, "")
+    }), {}),
+    cache = optional(object({
+      paths   = optional(list(string), [""])
+    }), {})
+  })
+  default = {}
+
+  validation {
+    condition = (
+      length(var.git.credentials.username) == 0 ||
+      length(var.git.credentials.token-secret-arn) > 0
+    )
+    error_message = "When credentials.username is set, credentials.token-secret-arn must also be provided."
+  }
+}
+
 variable "task" {
   description = "Conrol plane task definition."
   type = object({

--- a/terraform/examples/AWS-private-package/README.md
+++ b/terraform/examples/AWS-private-package/README.md
@@ -118,8 +118,8 @@ module "control-plane" {
   locations        = [module.location]
   private-package  = module.private-package
   # task = {
-  #   cpu    = "1024"
-  #   memory = "3072"
+  #   cpu             = "1024"
+  #   memory          = "3072"
   #   init = {
   #     image = "busybox"
   #   }
@@ -129,6 +129,21 @@ module "control-plane" {
   #   environment     = []
   #   cloudwatch-logs = true
   #   ecr             = false
+  # }
+  # git = {
+  #   Configure git credentials for the control plane. Requires builder image: "gatlingcorp/control-plane:latest-builder"
+  #   Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
+  #   host = "github.com"
+  #   credentials = {
+  #     username         = "<GitUsername>"
+  #     token-secret-arn = "<GitTokenSecretARN>"
+  #   }
+  #   ssh = {
+  #     private-key-secret-arn = "<GitSSHPrivateKeySecretARN>"
+  #   }
+  #   cache = {
+  #     paths = ["/app/.m2", "/app/.gradle", "/app/.sbt", "/app/.npm"]
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the control plane

--- a/terraform/examples/AWS-private-package/main.tf
+++ b/terraform/examples/AWS-private-package/main.tf
@@ -82,6 +82,21 @@ module "control-plane" {
   #   cloudwatch-logs = true
   #   ecr             = false
   # }
+  # git = {
+  #   Configure git credentials for the control plane. Requires builder image: "gatlingcorp/control-plane:latest-builder"
+  #   Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
+  #   host = "github.com"
+  #   credentials = {
+  #     username         = "<GitUsername>"
+  #     token-secret-arn = "<GitTokenSecretARN>"
+  #   }
+  #   ssh = {
+  #     private-key-secret-arn = "<GitSSHPrivateKeySecretARN>"
+  #   }
+  #   cache = {
+  #     paths = ["/app/.m2", "/app/.gradle", "/app/.sbt", "/app/.npm"]
+  #   }
+  # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the control plane
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy


### PR DESCRIPTION
Motivation:
Enable building from source by allowing end users to integrate their Git credentials or SSH key.

Modifications:
- Update the init container in the ECS module to inject the required SSH key or Git credentials.
- Mount the necessary volumes to the appropriate paths for both the init container and the control plane container within the ECS module.
- Add the required IAM permissions to read Git secrets (password/token and SSH private key) from AWS Secrets Manager (ASM).