### PR TITLE
[TF-AWS] fix: set default cache paths to [] instead of [""]

### DIFF
--- a/terraform/aws/control-plane/variables.tf
+++ b/terraform/aws/control-plane/variables.tf
@@ -43,7 +43,7 @@ variable "assign-public-ip" {
 variable "git" {
   description = "Conrol plane git configuration."
   type = object({
-    host = optional(string, "")
+    host = optional(string, "github.com")
     credentials = optional(object({
       username            = optional(string, "")
       token-secret-arn = optional(string, "")
@@ -52,7 +52,7 @@ variable "git" {
       private-key-secret-arn = optional(string, "")
     }), {}),
     cache = optional(object({
-      paths   = optional(list(string), [""])
+      paths   = optional(list(string), [])
     }), {})
   })
   default = {}


### PR DESCRIPTION
Motivation:
Fix the issue `containerPath should not be null or empty.`

Modifications:
Replace the default value `git.cache.paths = [""]` with an empty array `[]`.