### PR TITLE
fix: allow get secret value of task secrets, closes misc-510

### DIFF
--- a/terraform/aws/control-plane/main.tf
+++ b/terraform/aws/control-plane/main.tf
@@ -8,8 +8,7 @@ module "iam" {
   locations        = var.locations
   private-package  = var.private-package
   git              = var.git
-  cloudwatch-logs  = var.task.cloudwatch-logs
-  ecr              = var.task.ecr
+  task             = var.task
 }
 
 module "ecs" {

--- a/terraform/aws/control-plane/modules/iam/variables.tf
+++ b/terraform/aws/control-plane/modules/iam/variables.tf
@@ -39,12 +39,11 @@ variable "git" {
   })
 }
 
-variable "cloudwatch-logs" {
-  description = "Control Plane CloudWatch Logs."
-  type        = bool
-}
-
-variable "ecr" {
-  description = "Enable ECR IAM Permissions."
-  type        = bool
+variable "task" {
+  description = "Conrol plane task definition."
+  type = object({
+    secrets         = list(map(string))
+    cloudwatch-logs = bool
+    ecr             = bool
+  })
 }


### PR DESCRIPTION
[fix: allow get secret value of task secrets, closes misc-510](https://github.com/gatling/gatling-enterprise-control-plane-deployment/commit/e7f805a9479d0e42a0b02ae84f1d7dfdab3ed253)

**Motivation:**
Task fail to deploy because configured secrets are not readable.

**Modification:**
Add all secrets ARN from task to IAM role allowing to get secret value.

---

`terraform plan` with `task.secrets = [{ "valueFrom": "test"}]`
```
  # module.control-plane.module.iam.aws_iam_policy.asm_policy will be created
  + resource "aws_iam_policy" "asm_policy" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + id               = (known after apply)
      + name             = "tpetillot-control-plane-asm-policy"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "secretsmanager:GetSecretValue",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:secretsmanager:eu-west-3:052332116824:secret:tpetillot-control-plane-token-bVaY6t",
                          + "test",
                          + "arn:aws:secretsmanager:eu-west-3:052332116824:secret:tpetillot-control-plane-ssh-key-mezJqJ",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = (known after apply)
    }
```