### PR TITLE
[TF-Azure] Build from sources support

### DIFF
--- a/terraform/azure/control-plane/modules/container-app/main.tf
+++ b/terraform/azure/control-plane/modules/container-app/main.tf
@@ -1,16 +1,115 @@
 locals {
-  path        = "/app/conf"
-  volume-name = "control-plane-conf"
-  secret-name = "token-secret-id"
-  environment = concat(
+  conf_path       = "/app/conf"
+  ssh_path        = "/app/.ssh"
+  file_share_path = "/app/.file-share"
+  git_path        = "${local.conf_path}/.git-credentials"
+  volume_name     = "control-plane-conf"
+  ssh_volume_name = "ssh-key-vol"
+  file_share_name = "file-share-vol"
+  git = {
+    ssh_enabled   = length(var.git.ssh.storage-account-name) > 0
+    creds_enabled = length(var.git.credentials.username) > 0 && length(var.git.credentials.token-secret-id) > 0
+  }
+  secrets = concat(
     [
       {
         name        = "CONTROL_PLANE_TOKEN"
-        secret-name = local.secret-name
+        secret-name = "control-plane-token"
+        secret-id   = var.token-secret-id
+      }
+  ], var.container-app.secrets)
+  environment = concat(
+    local.git.creds_enabled ?
+    [
+      {
+        name  = "GIT_CREDENTIALS"
+        value = local.git_path
+      }
+    ] : [],
+  var.container-app.environment)
+  config_content = <<-EOF
+    control-plane {
+      token = $${?CONTROL_PLANE_TOKEN}
+      description = "${var.description}"
+      enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
+      locations = [%{for location in var.locations} ${jsonencode(location.conf)}, %{endfor}]
+      %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
+      %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
+    }
+  EOF
+  mountPoints = concat(
+    [
+      {
+        sourceVolume : local.volume_name
+        containerPath : local.conf_path
       }
     ],
-    var.container.environment
-  )
+    local.git.ssh_enabled ? [
+      {
+        sourceVolume : local.ssh_volume_name
+        containerPath : local.ssh_path
+      }
+    ] : [],
+    [
+      for cache_path in var.git.cache.paths : {
+        sourceVolume  = local.volume_name
+        containerPath = cache_path
+      }
+  ])
+  init_commands = compact([
+    "echo \"$CONFIG_CONTENT\" > ${local.conf_path}/control-plane.conf && chown -R 1001 ${local.conf_path} && chmod 400 ${local.conf_path}/control-plane.conf",
+    local.git.ssh_enabled ? "echo 'Host ${var.git.host}\n IdentityFile ${local.ssh_path}/${var.git.ssh.file-name}\n StrictHostKeyChecking no' >> ${local.ssh_path}/config && cp ${local.file_share_path}/${var.git.ssh.file-name} ${local.ssh_path}/${var.git.ssh.file-name} && chown -R 1001 ${local.ssh_path} && chmod 400 ${local.ssh_path}/config ${local.ssh_path}/${var.git.ssh.file-name}" : "",
+    local.git.creds_enabled ? "echo \"https://$GIT_USERNAME:$GIT_TOKEN@${var.git.host}\" > ${local.git_path} && chown -R 1001 ${local.conf_path} && chmod 400 ${local.git_path}" : ""
+  ])
+  init = {
+    command = [
+      "/bin/sh",
+      "-c",
+      join(" && ", local.init_commands)
+    ]
+    secrets = local.git.creds_enabled ? [
+      {
+        name        = "GIT_TOKEN"
+        secret-name = "git-token"
+        secret-id   = var.git.credentials.token-secret-id
+      }
+    ] : []
+    environment = concat(
+      [
+        {
+          name  = "CONFIG_CONTENT"
+          value = local.config_content
+        }
+      ],
+      local.git.creds_enabled ? [
+        {
+          name  = "GIT_USERNAME"
+          value = var.git.credentials.username
+        },
+        {
+          name  = "GIT_CREDENTIALS"
+          value = local.git_path
+        }
+      ] : []
+    )
+    mountPoints = concat(
+      [
+        {
+          sourceVolume : local.volume_name
+          containerPath : local.conf_path
+        }
+      ],
+      local.git.ssh_enabled ? [
+        {
+          sourceVolume : local.ssh_volume_name
+          containerPath : local.ssh_path
+        },
+        {
+          sourceVolume : local.file_share_name
+          containerPath : local.file_share_path
+        }
+    ] : [])
+  }
 }
 
 resource "azurerm_container_app_environment" "gatling_container_env" {
@@ -20,11 +119,12 @@ resource "azurerm_container_app_environment" "gatling_container_env" {
 }
 
 resource "azurerm_container_app_environment_storage" "gatling_container_env_storage" {
-  name                         = local.volume-name
+  count                        = local.git.ssh_enabled ? 1 : 0
+  name                         = local.file_share_name
   container_app_environment_id = azurerm_container_app_environment.gatling_container_env.id
-  account_name                 = var.storage.account-name
-  share_name                   = var.storage.share-name
-  access_key                   = var.storage.account-primary-access-key
+  account_name                 = var.git.ssh.storage-account-name
+  share_name                   = var.git.ssh.file-share-name
+  access_key                   = var.git.ssh.account-primary-access-key
   access_mode                  = "ReadOnly"
 }
 
@@ -50,25 +150,28 @@ resource "azurerm_container_app" "gatling_container" {
     }
   }
 
-  secret {
-    name                = local.secret-name
-    key_vault_secret_id = var.secret-id
-    identity            = "System"
+  dynamic "secret" {
+    for_each = concat(local.init.secrets, local.secrets)
+    content {
+      name                = secret.value.secret-name
+      key_vault_secret_id = secret.value.secret-id
+      identity            = "System"
+    }
   }
 
   template {
     min_replicas = 1
     max_replicas = 1
 
-    container {
-      name    = "control-plane"
-      image   = var.container.image
-      cpu     = var.container.cpu
-      memory  = var.container.memory
-      command = var.container.command
+    init_container {
+      name    = "conf-loader-init-container"
+      image   = var.container-app.init.image
+      cpu     = "0.25"
+      memory  = "0.5Gi"
+      command = local.init.command
 
       dynamic "env" {
-        for_each = local.environment
+        for_each = concat(local.init.environment, local.init.secrets)
         content {
           name        = env.value.name
           value       = lookup(env.value, "value", null)
@@ -76,16 +179,60 @@ resource "azurerm_container_app" "gatling_container" {
         }
       }
 
-      volume_mounts {
-        name = local.volume-name
-        path = local.path
+      dynamic "volume_mounts" {
+        for_each = local.init.mountPoints
+        content {
+          name = volume_mounts.value.sourceVolume
+          path = volume_mounts.value.containerPath
+        }
+      }
+    }
+
+    container {
+      name    = "control-plane"
+      image   = var.container-app.image
+      cpu     = var.container-app.cpu
+      memory  = var.container-app.memory
+      command = var.container-app.command
+
+      dynamic "env" {
+        for_each = concat(local.environment, local.secrets)
+        content {
+          name        = env.value.name
+          value       = lookup(env.value, "value", null)
+          secret_name = lookup(env.value, "secret-name", null)
+        }
+      }
+
+      dynamic "volume_mounts" {
+        for_each = local.mountPoints
+        content {
+          name = volume_mounts.value.sourceVolume
+          path = volume_mounts.value.containerPath
+        }
       }
     }
 
     volume {
-      name         = local.volume-name
-      storage_name = local.volume-name
-      storage_type = "AzureFile"
+      name         = local.volume_name
+      storage_type = "EmptyDir"
+    }
+
+    dynamic "volume" {
+      for_each = local.git.ssh_enabled ? [1] : []
+      content {
+        name         = local.ssh_volume_name
+        storage_type = "EmptyDir"
+      }
+    }
+
+    dynamic "volume" {
+      for_each = local.git.ssh_enabled ? [1] : []
+      content {
+        name         = local.file_share_name
+        storage_name = local.file_share_name
+        storage_type = "AzureFile"
+      }
     }
   }
 

--- a/terraform/azure/control-plane/modules/container-app/variables.tf
+++ b/terraform/azure/control-plane/modules/container-app/variables.tf
@@ -3,7 +3,12 @@ variable "name" {
   type        = string
 }
 
-variable "secret-id" {
+variable "description" {
+  description = "Description of the control plane."
+  type        = string
+}
+
+variable "token-secret-id" {
   description = "Secret identifier where the control token plane is stored."
   type        = string
 }
@@ -18,28 +23,56 @@ variable "resource-group-name" {
   type        = string
 }
 
-variable "container" {
-  description = "Container settings."
+variable "container-app" {
+  description = "Container app settings."
   type = object({
+    init = object({
+      image = string
+    })
     cpu         = number
     memory      = string
     image       = string
-    command     = optional(list(string))
-    environment = optional(list(map(string)))
+    command     = list(string)
+    secrets     = list(map(string))
+    environment = list(map(string))
   })
 }
 
-variable "storage" {
-  description = "Storage options."
+variable "git" {
+  description = "Conrol plane git configuration."
   type = object({
-    account-name               = string
-    account-primary-access-key = string
-    share-name                 = string
+    host = string
+    credentials = object({
+      username        = string
+      token-secret-id = string
+    })
+    ssh = object({
+      storage-account-name       = string
+      file-share-name            = string
+      file-name                  = string
+      account-primary-access-key = optional(string)
+    }),
+    cache = object({
+      paths = list(string)
+    })
   })
+}
+
+variable "locations" {
+  description = "JSON configuration for the locations."
+  type        = list(any)
 }
 
 variable "private-package" {
   description = "JSON configuration for the private packages."
   type        = map(any)
   default     = {}
+}
+
+variable "enterprise-cloud" {
+  type = map(any)
+}
+
+variable "extra-content" {
+  type = map(any)
 }

--- a/terraform/azure/control-plane/modules/role-assignment/main.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_role_definition" "gatling_custom_role" {
   description = "Role for Gatling Control plane permissions."
 
   permissions {
-    actions = [
+    actions = concat([
       "Microsoft.MarketplaceOrdering/agreements/offers/plans/read",
       "Microsoft.MarketplaceOrdering/agreements/offers/plans/sign/action",
       "Microsoft.Resources/subscriptions/resourceGroups/write",
@@ -27,12 +27,13 @@ resource "azurerm_role_definition" "gatling_custom_role" {
       "Microsoft.Network/publicIPAddresses/write",
       "Microsoft.Network/networkInterfaces/write",
       "Microsoft.Network/networkInterfaces/join/action",
-      "Microsoft.Storage/storageAccounts/read",
-      "Microsoft.Storage/storageAccounts/listkeys/action",
       "Microsoft.Compute/galleries/images/versions/read",
       "Microsoft.Compute/virtualMachines/read",
       "Microsoft.Compute/virtualMachines/write"
-    ]
+      ], var.storage ? [
+      "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.Storage/storageAccounts/listkeys/action"
+    ] : [])
   }
 }
 

--- a/terraform/azure/control-plane/modules/role-assignment/variables.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/variables.tf
@@ -18,3 +18,8 @@ variable "private-package" {
   type        = map(any)
   default     = {}
 }
+
+variable "storage" {
+  description = "Boolean to indicate if the storage account is used."
+  type = bool
+}

--- a/terraform/azure/control-plane/modules/storage-account/main.tf
+++ b/terraform/azure/control-plane/modules/storage-account/main.tf
@@ -1,42 +1,4 @@
-locals {
-  conf-file-name = "control-plane.conf"
-}
-
 data "azurerm_storage_account" "gatling_storage_account" {
   name                = var.storage-account-name
   resource_group_name = var.resource-group-name
-}
-
-resource "azurerm_storage_share" "gatling_storage_share" {
-  name               = "${var.storage-account-name}-file-share"
-  storage_account_id = data.azurerm_storage_account.gatling_storage_account.id
-  quota              = 50
-}
-
-resource "local_file" "json_file" {
-  filename = local.conf-file-name
-  content  = <<-EOF
-    control-plane {
-      token = $${?CONTROL_PLANE_TOKEN}
-      description = "${var.description}"
-      enterprise-cloud = ${jsonencode(var.enterprise-cloud)}
-      locations = [%{for location in var.locations} ${jsonencode(location.conf)}, %{endfor}]
-      %{if length(var.private-package) > 0}repository = ${jsonencode(var.private-package.conf)}%{endif}
-      %{for key, value in var.extra-content}${key} = "${value}"%{endfor}
-    }
-  EOF
-}
-
-resource "azurerm_storage_share_file" "gatling_storage_share_file" {
-  name             = local.conf-file-name
-  storage_share_id = azurerm_storage_share.gatling_storage_share.url
-  source           = local_file.json_file.filename
-
-  lifecycle {
-    replace_triggered_by = [
-      local_file.json_file.content
-    ]
-  }
-
-  depends_on = [local_file.json_file]
 }

--- a/terraform/azure/control-plane/modules/storage-account/outputs.tf
+++ b/terraform/azure/control-plane/modules/storage-account/outputs.tf
@@ -1,9 +1,3 @@
-output "primary-access-key" {
-  value       = data.azurerm_storage_account.gatling_storage_account.primary_access_key
-  description = "Primary key for the storage account"
-}
-
-output "share-name" {
-  value       = azurerm_storage_share.gatling_storage_share.name
-  description = "Storage share name used to store the configuration."
+output "primary_access_key" {
+  value = data.azurerm_storage_account.gatling_storage_account.primary_access_key
 }

--- a/terraform/azure/control-plane/modules/storage-account/variables.tf
+++ b/terraform/azure/control-plane/modules/storage-account/variables.tf
@@ -1,8 +1,3 @@
-variable "description" {
-  description = "Description of the control plane."
-  type        = string
-}
-
 variable "resource-group-name" {
   description = "Region of the control plane and its resources"
   type        = string
@@ -11,22 +6,4 @@ variable "resource-group-name" {
 variable "storage-account-name" {
   description = "The name of the existing storage account"
   type        = string
-}
-
-variable "locations" {
-  description = "JSON configuration for the locations."
-  type        = list(any)
-}
-
-variable "private-package" {
-  description = "JSON configuration for the private packages."
-  type        = map(any)
-}
-
-variable "enterprise-cloud" {
-  type    = map(any)
-}
-
-variable "extra-content" {
-  type    = map(any)
 }

--- a/terraform/azure/private-package/main.tf
+++ b/terraform/azure/private-package/main.tf
@@ -4,7 +4,7 @@ locals {
     storage-account : var.storage-account-name
     container : var.control-plane-name
     path : var.path
-    upload  = var.upload
-    server  = var.server
+    upload  : var.upload
+    server  : var.server
   }
 }

--- a/terraform/examples/AZURE-private-location/README.md
+++ b/terraform/examples/AZURE-private-location/README.md
@@ -75,16 +75,18 @@ Sets up the control plane with configurations for networking, security, and stor
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  description          = "My Azure control plane description"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  # container = {
+  source              = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
+  name                = "<Name>"
+  description         = "My Azure control plane description"
+  vault-name          = "<Vault>"
+  token-secret-id     = "<TokenSecretIdentifier>"
+  region              = "<Region>"
+  resource-group-name = "<ResourceGroup>"
+  locations           = [module.location]
+  # container-app = {
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   cpu         = 1.0
   #   memory      = "2Gi"
   #   image       = "gatlingcorp/control-plane:latest"

--- a/terraform/examples/AZURE-private-location/main.tf
+++ b/terraform/examples/AZURE-private-location/main.tf
@@ -33,16 +33,18 @@ module "location" {
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  description          = "My Azure control plane description"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  # container = {
+  source              = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
+  name                = "<Name>"
+  description         = "My Azure control plane description"
+  vault-name          = "<Vault>"
+  token-secret-id     = "<TokenSecretIdentifier>"
+  region              = "<Region>"
+  resource-group-name = "<ResourceGroup>"
+  locations           = [module.location]
+  # container-app = {
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   cpu         = 1.0
   #   memory      = "2Gi"
   #   image       = "gatlingcorp/control-plane:latest"

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -125,8 +125,8 @@ module "control-plane" {
   #   # Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
   #   host = "github.com"
   #   credentials = {
-  #     username        = "karimatwa"
-  #     token-secret-id = "https://gatlingvault.vault.azure.net/secrets/github-token/fd927b5f46c648fb84302991e78403d2"
+  #     username        = "<GitUsername>"
+  #     token-secret-id = "<GitTokenSecretId>"
   #   }
   #   ssh = {
   #     storage-account-name = "presalest"

--- a/terraform/examples/AZURE-private-package/README.md
+++ b/terraform/examples/AZURE-private-package/README.md
@@ -101,22 +101,41 @@ Sets up the control plane with configurations for networking, security, and stor
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  description          = "My Azure control plane description"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  private-package      = module.private-package
-  # container = {
+  source              = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
+  name                = "<Name>"
+  description         = "My Azure control plane description"
+  vault-name          = "<Vault>"
+  token-secret-id     = "<TokenSecretIdentifier>"
+  region              = "<Region>"
+  resource-group-name = "<ResourceGroup>"
+  locations           = [module.location]
+  private-package     = module.private-package
+  # container-app = {
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   cpu         = 1.0
   #   memory      = "2Gi"
   #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
+  # }
+  # git = {
+  #   # Configure git credentials for the control plane. Requires builder image: "gatlingcorp/control-plane:latest-builder"
+  #   # Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
+  #   host = "github.com"
+  #   credentials = {
+  #     username        = "karimatwa"
+  #     token-secret-id = "https://gatlingvault.vault.azure.net/secrets/github-token/fd927b5f46c648fb84302991e78403d2"
+  #   }
+  #   ssh = {
+  #     storage-account-name = "presalest"
+  #     file-share-name      = "presalest"
+  #     file-name            = "key.pem"
+  #   }
+  #   cache = {
+  #     paths = ["/app/.m2", "/app/.gradle", "/app/.sbt", "/app/.npm"]
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -78,8 +78,8 @@ module "control-plane" {
   #   # Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
   #   host = "github.com"
   #   credentials = {
-  #     username        = "karimatwa"
-  #     token-secret-id = "https://gatlingvault.vault.azure.net/secrets/github-token/fd927b5f46c648fb84302991e78403d2"
+  #     username        = "<GitUsername>"
+  #     token-secret-id = "<GitTokenSecretId>"
   #   }
   #   ssh = {
   #     storage-account-name = "<StorageAccountName>"

--- a/terraform/examples/AZURE-private-package/main.tf
+++ b/terraform/examples/AZURE-private-package/main.tf
@@ -54,22 +54,41 @@ module "location" {
 # Create a control plane based on Azure Container App
 # Reference: https://docs.gatling.io/reference/install/cloud/private-locations/azure/installation/
 module "control-plane" {
-  source               = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
-  name                 = "<Name>"
-  description          = "My Azure control plane description"
-  vault-name           = "<Vault>"
-  secret-id            = "<SecretIdentifier>"
-  region               = "<Region>"
-  resource-group-name  = "<ResourceGroup>"
-  storage-account-name = "<StorageAccount>"
-  locations            = [module.location]
-  private-package      = module.private-package
-  # container = {
+  source              = "git::https://github.com/gatling/gatling-enterprise-control-plane-deployment//terraform/azure/control-plane"
+  name                = "<Name>"
+  description         = "My Azure control plane description"
+  vault-name          = "<Vault>"
+  token-secret-id     = "<TokenSecretIdentifier>"
+  region              = "<Region>"
+  resource-group-name = "<ResourceGroup>"
+  locations           = [module.location]
+  private-package     = module.private-package
+  # container-app = {
+  #   init = {
+  #     image = "busybox"
+  #   }
   #   cpu         = 1.0
   #   memory      = "2Gi"
   #   image       = "gatlingcorp/control-plane:latest"
   #   command     = []
   #   environment = []
+  # }
+  # git = {
+  #   # Configure git credentials for the control plane. Requires builder image: "gatlingcorp/control-plane:latest-builder"
+  #   # Reference: https://docs.gatling.io/reference/execute/cloud/user/build-from-sources/
+  #   host = "github.com"
+  #   credentials = {
+  #     username        = "karimatwa"
+  #     token-secret-id = "https://gatlingvault.vault.azure.net/secrets/github-token/fd927b5f46c648fb84302991e78403d2"
+  #   }
+  #   ssh = {
+  #     storage-account-name = "<StorageAccountName>"
+  #     file-share-name      = "<FileShareName>"
+  #     file-name            = "<FileName>"
+  #   }
+  #   cache = {
+  #     paths = ["/app/.m2", "/app/.gradle", "/app/.sbt", "/app/.npm"]
+  #   }
   # }
   # enterprise-cloud = {
   #   Setup the proxy configuration for the private location


### PR DESCRIPTION
Motivation:
Enable building from source by allowing end users to integrate their Git credentials or SSH key.

Modifications:

- Add an init container in the container-app module to inject the required SSH key or Git credentials & CP config.
- Mount the necessary volumes to the appropriate paths for both the init container and the control plane container within the container-app module.
- Add conditional custom role permissions to retrieve git credentials/SSH private key from Key Vault/Storage Account.