### PR TITLE
fix: correct indentation for podLabels in service.yaml

### DIFF
--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ .Values.controlPlane.name }}
       {{- with .Values.controlPlane.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 4 }}
       {{- end }}
   ports:
   {{ toYaml .Values.privatePackage.repository.service.ports | nindent 2 }}


### PR DESCRIPTION
When using podLabels an error occured on service manifest because of a bad indentation