### PR TITLE
fix: add missing resourceGroups read permission

### DIFF
--- a/terraform/azure/control-plane/modules/role-assignment/main.tf
+++ b/terraform/azure/control-plane/modules/role-assignment/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_role_definition" "gatling_custom_role" {
     actions = concat([
       "Microsoft.MarketplaceOrdering/agreements/offers/plans/read",
       "Microsoft.MarketplaceOrdering/agreements/offers/plans/sign/action",
+      "Microsoft.Resources/subscriptions/resourceGroups/read",
       "Microsoft.Resources/subscriptions/resourceGroups/write",
       "Microsoft.Resources/subscriptions/resourceGroups/delete",
       "Microsoft.MarketplaceOrdering/offertypes/publishers/offers/plans/agreements/read",


### PR DESCRIPTION
Motivation:
Resource group remains after a simulation is completed and the virtual machine(s), IP(s), and disk(s) are not deleted.

Modification:
Add missing Azure permission on the custom role in order to read resourceGroups.
`Microsoft.Resources/subscriptions/resourceGroups/read`