### PR TITLE
[GCP TF] Feat: add optional project field for location's network interface

### DIFF
--- a/terraform/examples/GCP-private-location/README.md
+++ b/terraform/examples/GCP-private-location/README.md
@@ -64,7 +64,7 @@ module "location" {
   #   network-interface = {
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
-  #     with-external-ip = false
+  #     with-external-ip = true
   #   }
   # }
   # system-properties = {}

--- a/terraform/examples/GCP-private-location/README.md
+++ b/terraform/examples/GCP-private-location/README.md
@@ -62,6 +62,7 @@ module "location" {
   #     sizeGb = 20
   #   }
   #   network-interface = {
+  #     project          = "<NetworkInterfaceProjectName>"
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
   #     with-external-ip = true

--- a/terraform/examples/GCP-private-location/main.tf
+++ b/terraform/examples/GCP-private-location/main.tf
@@ -29,7 +29,7 @@ module "location" {
   #   network-interface = {
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
-  #     with-external-ip = false
+  #     with-external-ip = true
   #   }
   # }
   # system-properties = {}

--- a/terraform/examples/GCP-private-location/main.tf
+++ b/terraform/examples/GCP-private-location/main.tf
@@ -27,6 +27,7 @@ module "location" {
   #     sizeGb = 20
   #   }
   #   network-interface = {
+  #     project          = "<NetworkInterfaceProjectName>"
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
   #     with-external-ip = true

--- a/terraform/examples/GCP-private-package/README.md
+++ b/terraform/examples/GCP-private-package/README.md
@@ -89,6 +89,7 @@ module "location" {
   #     sizeGb = 20
   #   }
   #   network-interface = {
+  #     project          = "<NetworkInterfaceProjectName>"
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
   #     with-external-ip = true

--- a/terraform/examples/GCP-private-package/README.md
+++ b/terraform/examples/GCP-private-package/README.md
@@ -91,7 +91,7 @@ module "location" {
   #   network-interface = {
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
-  #     with-external-ip = false
+  #     with-external-ip = true
   #   }
   # }
   # system-properties = {}

--- a/terraform/examples/GCP-private-package/main.tf
+++ b/terraform/examples/GCP-private-package/main.tf
@@ -50,7 +50,7 @@ module "location" {
   #   network-interface = {
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
-  #     with-external-ip = false
+  #     with-external-ip = true
   #   }
   # }
   # system-properties = {}

--- a/terraform/examples/GCP-private-package/main.tf
+++ b/terraform/examples/GCP-private-package/main.tf
@@ -48,6 +48,7 @@ module "location" {
   #     sizeGb = 20
   #   }
   #   network-interface = {
+  #     project          = "<NetworkInterfaceProjectName>"
   #     network          = "<Network>"
   #     subnetwork       = "<SubNetwork>"
   #     with-external-ip = true

--- a/terraform/gcp/location/variables.tf
+++ b/terraform/gcp/location/variables.tf
@@ -55,6 +55,7 @@ variable "machine" {
     }), {})
     disk = optional(object({ sizeGb = number }), { sizeGb = 20 })
     network-interface = optional(object({
+      project          = optional(string)
       network          = optional(string)
       subnetwork       = optional(string)
       with-external-ip = optional(bool, true)


### PR DESCRIPTION
Motivation:
Create a load generator under a project, but with a shared VPC network/subnetwork from a host project. 

Modifications:
Add an extra optional project field in the network-interface of the GCP location configuration block.