### PR TITLE
feat: replace toJson w/ manual rendering for system properties

### DIFF
--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -68,7 +68,15 @@ control-plane {
       machine = {{ toJson .machine }}
     {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
-      system-properties = {{ toJson .systemProperties }}
+      system-properties = [
+      {{- range $index, $prop := .systemProperties }}
+        {{- if $index }},{{ end }}
+        {
+          "name": "{{ $prop.name }}",
+          "value": {{ $prop.value }}
+        }
+      {{- end }}
+      ]
     {{- if .javaHome }}
       java-home = "{{ .javaHome }}"
     {{- end }}


### PR DESCRIPTION
Motivation:
The current implementation uses `toJson` to serialize the `systemProperties` values, resulting in placeholders like `${?API_KEY}` being rendered as quoted strings. This breaks downstream the HOCON that expect these values to be interpreted as raw environment variable references rather than string literals.

Modifications:
Replaced the `toJson` function with a manual loop over `.systemProperties.`