### PR TITLE
fix: convert system-properties list to map

### DIFF
--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -68,15 +68,11 @@ control-plane {
       machine = {{ toJson .machine }}
     {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
-      system-properties = [
-      {{- range $index, $prop := .systemProperties }}
-        {{- if $index }},{{ end }}
-        {
-          "name": "{{ $prop.name }}",
-          "value": {{ $prop.value }}
-        }
+      system-properties = {
+      {{- range $key, $val := .systemProperties }}
+        {{ $key }} = {{ $val }}
       {{- end }}
-      ]
+      }
     {{- if .javaHome }}
       java-home = "{{ .javaHome }}"
     {{- end }}


### PR DESCRIPTION
Motivation:
Location system properties are expected as a map and not a list.

Modifications:
Convert system properties to a map in _config.tpl