### PR TITLE
[Helm] Fix: Enforce quotes on system properties keys

### DIFF
--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -68,15 +68,11 @@ control-plane {
       machine = {{ toJson .machine }}
     {{- end }}
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
-      system-properties = [
-      {{- range $index, $prop := .systemProperties }}
-        {{- if $index }},{{ end }}
-        {
-          "name": "{{ $prop.name }}",
-          "value": {{ $prop.value }}
-        }
+      system-properties = {
+      {{- range $key, $val := .systemProperties }}
+        {{ $key }} = {{ $val }}
       {{- end }}
-      ]
+      }
     {{- if .javaHome }}
       java-home = "{{ .javaHome }}"
     {{- end }}

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -70,7 +70,7 @@ control-plane {
       debug.keep-load-generator-alive = {{ toJson (default false .keepLoadGeneratorAlive) }}
       system-properties = {
       {{- range $key, $val := .systemProperties }}
-        {{ $key }} = {{ $val }}
+        "{{ $key }}" = {{ $val }}
       {{- end }}
       }
     {{- if .javaHome }}


### PR DESCRIPTION
Motivation:
Enforce location system property keys as strings.