### PR TITLE
Fix: assign location.machine default to null

### DIFF
--- a/terraform/examples/GCP-private-package/main.tf
+++ b/terraform/examples/GCP-private-package/main.tf
@@ -32,28 +32,28 @@ module "location" {
   description = "Private Location on GCP"
   project     = "<ProjectId>"
   zone        = "<Zone>"
+  machine = {
+    #   type        = "c3-highcpu-4"
+    #   preemptible = false
+    #   engine      = "classic"
+    #   image = {
+    #     type    = "certified"
+    #     java    = "latest"
+    #     project = "<ProjectName>"
+    #     family  = "<ImageFamily>"
+    #     id      = "<ImageId>"
+    #   }
+    #   disk = {
+    #     sizeGb = 20
+    #   }
+    #   network-interface = {
+    #     project          = "<NetworkInterfaceProjectName>"
+    #     network          = "<Network>"
+    #     subnetwork       = "<SubNetwork>"
+    #     with-external-ip = true
+    #   }
+  }
   # instance-template = "<InstanceTemplate>"
-  # machine = {
-  #   type        = "c3-highcpu-4"
-  #   preemptible = false
-  #   engine      = "classic"
-  #   image = {
-  #     type    = "certified"
-  #     java    = "latest"
-  #     project = "<ProjectName>"
-  #     family  = "<ImageFamily>"
-  #     id      = "<ImageId>"
-  #   }
-  #   disk = {
-  #     sizeGb = 20
-  #   }
-  #   network-interface = {
-  #     project          = "<NetworkInterfaceProjectName>"
-  #     network          = "<Network>"
-  #     subnetwork       = "<SubNetwork>"
-  #     with-external-ip = true
-  #   }
-  # }
   # system-properties = {}
   # java-home         = "/usr/lib/jvm/zulu"
   # jvm-options       = ["-Xmx4G", "-Xms512M"]

--- a/terraform/gcp/control-plane/modules/iam/main.tf
+++ b/terraform/gcp/control-plane/modules/iam/main.tf
@@ -26,7 +26,7 @@ locals {
   ]
 
   has_custom_image = anytrue([
-    for location in var.locations : location.conf.machine.image.type == "custom"
+    for location in var.locations : location.conf.machine != null ? location.conf.machine.image.type == "custom" : false
   ])
 
   has_instance_template = anytrue([

--- a/terraform/gcp/location/variables.tf
+++ b/terraform/gcp/location/variables.tf
@@ -61,33 +61,33 @@ variable "machine" {
       with-external-ip = optional(bool, true)
     }), {})
   })
-  default = {}
+  default = null
 
   validation {
-    condition     = contains(["classic", "javascript"], var.machine.engine)
+    condition     = var.machine == null ? true : contains(["classic", "javascript"], var.machine.engine)
     error_message = "The engine must be either 'classic' or 'javascript'."
   }
 
   validation {
-    condition     = contains(["certified", "custom"], var.machine.image.type)
+    condition     = var.machine == null ? true : contains(["certified", "custom"], var.machine.image.type)
     error_message = "The image type must be either 'certified' or 'custom'."
   }
 
   validation {
-    condition = var.machine.image.type != "custom" || (
+    condition = var.machine == null ? true : (var.machine.image.type != "custom" || (
       var.machine.image.project != null &&
       (var.machine.image.id != null || var.machine.image.family != null)
-    )
+    ))
     error_message = "If image.type is 'custom', then project must be defined and either id or family must be specified."
   }
 
   validation {
-    condition     = var.machine.disk.sizeGb >= 20
+    condition     = var.machine == null ? true : var.machine.disk.sizeGb >= 20
     error_message = "Disk sizeGb must be greater than or equal to 20."
   }
 
   validation {
-    condition     = can(regex("^[a-z][a-z0-9-]+$", var.machine.type))
+    condition     = var.machine == null ? true : can(regex("^[a-z][a-z0-9-]+$", var.machine.type))
     error_message = "Machine type must start with a letter and contain only lower-case letters, digits, or hyphens."
   }
 }


### PR DESCRIPTION
Motivation:
Users configuring `location.instance-template` expect the `location.machine` block to be entirely ignored. However, due to the default values assigned to `location.machine,` the configuration remains non-null even when omitted by the user. This leads to validation logic incorrectly detecting both instance-template and machine as present, triggering an error:

> either instance-template or machine configuration must be present

Modifications:
- Allowing `location.machine` to be null
- Preventing validation from running if `location.machine` is not defined



