### PR TITLE
Feat: add builder support on control plane

### DIFF
--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -4,9 +4,13 @@ control-plane {
   description = "{{ .Values.controlPlane.description }}"
   {{- if and .Values.controlPlane.builder (default false .Values.controlPlane.builder.enabled) }}
   builder {
-    git.global.credentials.https {
-      username = ${?GIT_USERNAME}
-      password = ${?GIT_TOKEN}
+    git.global.credentials {
+    {{- if eq .Values.controlPlane.builder.type "https" }}
+      https {
+        username = ${?GIT_USERNAME}
+        password = ${?GIT_TOKEN}
+      }
+    {{- end}}
     }
   }
   {{- end }}

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -5,7 +5,7 @@ control-plane {
   {{- if and .Values.controlPlane.builder (default false .Values.controlPlane.builder.enabled) }}
   builder {
     git.global.credentials {
-    {{- if eq .Values.controlPlane.builder.type "https" }}
+    {{- if eq .Values.controlPlane.builder.cloneOver "https" }}
       https {
         username = ${?GIT_USERNAME}
         password = ${?GIT_TOKEN}

--- a/helm-chart/templates/_config.tpl
+++ b/helm-chart/templates/_config.tpl
@@ -2,6 +2,14 @@
 control-plane {
   token = ${?CONTROL_PLANE_TOKEN}
   description = "{{ .Values.controlPlane.description }}"
+  {{- if and .Values.controlPlane.builder (default false .Values.controlPlane.builder.enabled) }}
+  builder {
+    git.global.credentials.https {
+      username = ${?GIT_USERNAME}
+      password = ${?GIT_TOKEN}
+    }
+  }
+  {{- end }}
   enterprise-cloud = {{ toJson .Values.controlPlane.enterpriseCloud }}
   locations = [
   {{- range .Values.privateLocations }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -12,6 +12,7 @@ controlPlane:
   # Build your own sources on the control plane (specify builder image, activate private packages & configure your env variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/).
   builder:
     enabled: false
+    type: https
   # ServiceAccount configuration: create set to true (create a new ServiceAccount with the given name.), or false (assume an existing ServiceAccount with the given name.)
   serviceAccount:
     create: true
@@ -37,7 +38,7 @@ controlPlane:
         secretKeyRef:
           name: gatling-enterprise
           key: api-token
-    # Builder env variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/.
+    # Builder HTTPS clone environment variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/.
     # - name: GIT_USERNAME # DO NOT CHANGE
     #   valueFrom:
     #     secretKeyRef:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -12,7 +12,7 @@ controlPlane:
   # Build your own sources on the control plane (specify builder image, activate private packages & configure your env variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/).
   builder:
     enabled: false
-    type: https
+    cloneOver: https
   # ServiceAccount configuration: create set to true (create a new ServiceAccount with the given name.), or false (assume an existing ServiceAccount with the given name.)
   serviceAccount:
     create: true

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -9,6 +9,9 @@ controlPlane:
   name: gatling-cp
   # Human-readable description for the Control Plane.
   description: My K8s control plane description
+  # Build your own sources on the control plane (specify builder image, activate private packages & configure your env variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/).
+  builder:
+    enabled: false
   # ServiceAccount configuration: create set to true (create a new ServiceAccount with the given name.), or false (assume an existing ServiceAccount with the given name.)
   serviceAccount:
     create: true
@@ -34,6 +37,17 @@ controlPlane:
         secretKeyRef:
           name: gatling-enterprise
           key: api-token
+    # Builder env variables GIT_USERNAME & GIT_TOKEN, ref: https://docs.gatling.io/reference/run-tests/build-from-sources/.
+    # - name: GIT_USERNAME # DO NOT CHANGE
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: git-https-auth
+    #       key: username
+    # - name: GIT_TOKEN # DO NOT CHANGE
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: git-https-auth
+    #       key: token
   # Override the default container entrypoint command if needed.
   command: []
   # Defines volumes for the Pod (e.g., configMaps, secrets, persistent volumes).


### PR DESCRIPTION
Motivation:
Support builder config with git authentication over HTTPS.

Modifications:
- Add `builder.enabled` & `builder.cloneOver` values.
- Add `git.global.credentials` configuration block on the cp config.