### PR TITLE
Feat: add container security context

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
         - name: {{ .Values.controlPlane.name }}
           image: {{ .Values.controlPlane.image.name }}
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          {{- if .Values.controlPlane.containerSecurityContext }}
+          securityContext:
+            {{ toYaml .Values.controlPlane.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- if .Values.controlPlane.command }}
           command:  
             {{ toYaml .Values.controlPlane.command | nindent 12 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -70,8 +70,10 @@ controlPlane:
     limits:
       memory: "1Gi"
       cpu: "1"
-  # Security context for running the container with specific privileges or user IDs.
+  # Security context for running the pod with specific privileges or user IDs.
   securityContext: {}
+  # Security context for running the container with specific privileges or user IDs.
+  containerSecurityContext: {}
   # enterpriseCloud:
   #   Setup proxy configuration for the control plane
   #   Reference: https://docs.gatling.io/reference/install/cloud/private-locations/network/#configuring-a-proxy


### PR DESCRIPTION
**Motivation:**
Adding container-level security context provides finer-grained control over permissions and runtime behavior beyond what the pod level security context can enforce. While the pod security context applies defaults to all containers, some workloads require specific overrides (e.g., restricting capabilities, defining read-only root filesystems, or dropping privileges for individual containers).

**Modifications:**
- Add `containerSecurityContext` on `values.yaml`.
- Add `securityContext` under containers in `deployment.yaml`