### PR TITLE
FIX: Remove non alpha numeric characters from iam instance profile name policy statements

### DIFF
--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -82,7 +82,7 @@ locals {
 
   iam_profile_name_statements = distinct([
     for location in var.locations : {
-      Sid      = "AllowPassRole${location.conf.iam-instance-profile}"
+      Sid = "AllowPassRole${replace(location.conf.iam-instance-profile, "/[^0-9A-Za-z]/", "")}"
       Effect   = "Allow"
       Action   = "iam:PassRole"
       Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${location.conf.iam-instance-profile}"

--- a/terraform/aws/control-plane/modules/iam/main.tf
+++ b/terraform/aws/control-plane/modules/iam/main.tf
@@ -82,7 +82,7 @@ locals {
 
   iam_profile_name_statements = distinct([
     for location in var.locations : {
-      Sid = "AllowPassRole${replace(location.conf.iam-instance-profile, "/[^0-9A-Za-z]/", "")}"
+      Sid      = "AllowPassRole${replace(location.conf.iam-instance-profile, "/[^0-9A-Za-z]/", "")}"
       Effect   = "Allow"
       Action   = "iam:PassRole"
       Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${location.conf.iam-instance-profile}"


### PR DESCRIPTION
**Motivation:** 

- In terraform AWS, Sid in `iam_profile_name_statements` doesn't allow non alpha numeric characters.


**Fix:**

- Sanitize Sid by replacing unallowed strings.
