### PR TITLE
fix: set correct policy on control plane role to pass location IAM profile role, closes CLD-7960

### DIFF
--- a/.github/workflows/terraform-workflow.yaml
+++ b/.github/workflows/terraform-workflow.yaml
@@ -42,6 +42,9 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
 
+      - name: Check Terraform formatting
+        run: terraform fmt -check -recursive terraform
+
       - name: Test Terraform AWS
         if: steps.filter.outputs.aws == 'true'
         run: |


### PR DESCRIPTION
**Motivation:**
Control plane failed to pass role related to location IAM profile.

**Modification:**
Use data source `aws_iam_instance_profile` to fetch the roles related to locations iam instance profile name. Update pass role policy with IAM profile role instead of IAM profile ARN.

**Result:**
Control plane is able to pass role related to the IAM profile.